### PR TITLE
Fase 2 backend — costeo, insumoId, auto-recalculo de recetas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "mime": "^4.0.4",
-        "mongodb": "^6.8.0",
+        "mongodb": "^6.21.0",
         "mongoose": "^8.4.4",
         "multer": "^1.4.5-lts.1",
         "node-cron": "^4.2.1",
@@ -2021,9 +2021,9 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
-      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
@@ -2096,6 +2096,52 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/mongodb": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
       }
     },
     "node_modules/mongoose/node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "mime": "^4.0.4",
-    "mongodb": "^6.8.0",
+    "mongodb": "^6.21.0",
     "mongoose": "^8.4.4",
     "multer": "^1.4.5-lts.1",
     "node-cron": "^4.2.1",

--- a/src/jobs/costeoHandler.js
+++ b/src/jobs/costeoHandler.js
@@ -1,0 +1,89 @@
+const Receta = require("../models/recetas/recetas");
+const TecnicaCreativa = require("../models/tecnicaCreativa");
+const Cost = require("../models/costs");
+
+/**
+ * Calcula y guarda el costeoSnapshot en una cotización.
+ *
+ * @param {Object} cotizacion  - documento Mongoose de la cotización
+ * @param {number} porciones   - número de porciones pedidas
+ * @param {Object} body        - { recetaId, tecnicaIds[], margenDeseado, ivaPercent? }
+ * @returns {Object}           - el snapshot calculado
+ */
+async function calcularCosteo(cotizacion, porciones, body) {
+  const { recetaId, tecnicaIds = [], margenDeseado = 0, ivaPercent = 16 } = body;
+
+  if (!recetaId) throw new Error("recetaId es obligatorio");
+  if (porciones <= 0) throw new Error("Las porciones deben ser > 0");
+
+  const [receta, tecnicas, costs] = await Promise.all([
+    Receta.findById(recetaId).lean(),
+    TecnicaCreativa.find({ _id: { $in: tecnicaIds }, activo: true }).lean(),
+    Cost.findOne().lean(),
+  ]);
+
+  if (!receta) throw new Error("Receta no encontrada");
+
+  const tarifaHora = costs?.laborCosts ?? 0;
+  const costoFijo = costs?.fixedCosts ?? 0;
+
+  const recetaRendimiento = receta.portions;
+  const recetasNecesarias = Math.ceil(porciones / recetaRendimiento);
+  const costoReceta = receta.total_cost * recetasNecesarias;
+
+  const tecnicasSnapshot = tecnicas.map((t) => {
+    const costoCalculado =
+      t.costoBase + t.escalaPorPorcion * porciones + t.tiempoHoras * tarifaHora;
+    return {
+      tecnicaId: t._id,
+      nombre: t.nombre,
+      costoBase: t.costoBase,
+      escalaPorPorcion: t.escalaPorPorcion,
+      tiempoHoras: t.tiempoHoras,
+      costoCalculado: round2(costoCalculado),
+    };
+  });
+
+  const costoTecnicasTotal = round2(
+    tecnicasSnapshot.reduce((s, t) => s + t.costoCalculado, 0)
+  );
+
+  const costoTotal = round2(costoReceta + costoTecnicasTotal + costoFijo);
+
+  const precioSugerido = round2(costoTotal * (1 + margenDeseado / 100));
+  const ivaImporte = round2(precioSugerido * (ivaPercent / 100));
+  const precioFinal = round2(precioSugerido + ivaImporte);
+  const gananciaNeta = round2(precioSugerido - costoTotal);
+
+  const snapshot = {
+    fechaCosteo: new Date(),
+    porciones,
+    recetaId: receta._id,
+    recetaNombre: receta.nombre_receta,
+    recetaRendimiento,
+    recetasNecesarias,
+    costoReceta: round2(costoReceta),
+    tecnicas: tecnicasSnapshot,
+    tarifaHoraSnapshot: tarifaHora,
+    costoFijoSnapshot: costoFijo,
+    costoTecnicasTotal,
+    costoTotal,
+    ivaPercent,
+    ivaImporte,
+    margenDeseado,
+    precioSugerido,
+    precioFinal,
+    gananciaNeta,
+  };
+
+  cotizacion.costeoSnapshot = snapshot;
+  await cotizacion.save();
+
+  return snapshot;
+}
+
+function round2(n) {
+  return Math.round(n * 100) / 100;
+}
+
+module.exports = { calcularCosteo };

--- a/src/jobs/reminderCron.js
+++ b/src/jobs/reminderCron.js
@@ -66,10 +66,12 @@ async function runReminders() {
 
   console.log(`[reminderCron] Buscando entregas en: ${targetDates.join(", ")}`);
 
+  // deliveryDate puede ser "DD/MM/YYYY" (seed) o "DD/MM/YYYY HH:MM" (form).
+  // $regex con ancla "^" matchea ambos formatos.
   const query = {
     status: "Agendado con el 50%",
     reminderSentAt: null,
-    deliveryDate: { $in: targetDates },
+    $or: targetDates.map((d) => ({ deliveryDate: { $regex: new RegExp(`^${d}`) } })),
   };
 
   const [pasteles, cupcakes, snacks] = await Promise.all([

--- a/src/models/costeoSnapshot.js
+++ b/src/models/costeoSnapshot.js
@@ -1,0 +1,50 @@
+const mongoose = require("mongoose");
+
+// Schema embebido en cada cotización — congela todos los valores al momento
+// del costeo para que futuras ediciones de recetas/técnicas no lo alteren.
+const costeoSnapshotSchema = new mongoose.Schema(
+  {
+    fechaCosteo: { type: Date, default: Date.now },
+    porciones: { type: Number, required: true },
+
+    // Receta base
+    recetaId: { type: mongoose.Schema.Types.ObjectId },
+    recetaNombre: { type: String },
+    recetaRendimiento: { type: Number },   // receta.portions (porciones por lote)
+    recetasNecesarias: { type: Number },   // Math.ceil(porciones / recetaRendimiento)
+    costoReceta: { type: Number },         // receta.total_cost * recetasNecesarias
+
+    // Técnicas creativas aplicadas (valores congelados)
+    tecnicas: [
+      {
+        tecnicaId: { type: mongoose.Schema.Types.ObjectId },
+        nombre: { type: String },
+        costoBase: { type: Number },
+        escalaPorPorcion: { type: Number },
+        tiempoHoras: { type: Number },
+        costoCalculado: { type: Number },
+      },
+    ],
+
+    // Tarifas operativas al momento del costeo (snapshot de Costs)
+    tarifaHoraSnapshot: { type: Number },
+    costoFijoSnapshot: { type: Number },
+
+    // Totales calculados
+    costoTecnicasTotal: { type: Number },
+    costoTotal: { type: Number },
+
+    // IVA
+    ivaPercent: { type: Number, default: 16 },
+    ivaImporte: { type: Number },
+
+    // Precio sugerido y ganancia
+    margenDeseado: { type: Number },   // % markup sobre costo total
+    precioSugerido: { type: Number },  // costoTotal * (1 + margenDeseado/100), sin IVA
+    precioFinal: { type: Number },     // precioSugerido + ivaImporte
+    gananciaNeta: { type: Number },    // precioSugerido - costoTotal
+  },
+  { _id: false }
+);
+
+module.exports = costeoSnapshotSchema;

--- a/src/models/cupcakesCotiza.js
+++ b/src/models/cupcakesCotiza.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const costeoSnapshotSchema = require("./costeoSnapshot");
 
 const cupcakesSchema = new mongoose.Schema(
   {
@@ -93,6 +94,11 @@ const cupcakesSchema = new mongoose.Schema(
     },
     userId: {
       type: String,
+    },
+    images: [{ type: String }],
+    costeoSnapshot: {
+      type: costeoSnapshotSchema,
+      default: null,
     },
   },
   {

--- a/src/models/pastelCotiza.js
+++ b/src/models/pastelCotiza.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const costeoSnapshotSchema = require("./costeoSnapshot");
 
 const pastelSchema = new mongoose.Schema(
   {
@@ -110,6 +111,11 @@ const pastelSchema = new mongoose.Schema(
     },
     userId: {
       type: String,
+    },
+    images: [{ type: String }],
+    costeoSnapshot: {
+      type: costeoSnapshotSchema,
+      default: null,
     },
   },
   {

--- a/src/models/producto.js
+++ b/src/models/producto.js
@@ -1,0 +1,14 @@
+const mongoose = require("mongoose");
+
+const productoSchema = new mongoose.Schema(
+  {
+    nombre: { type: String, required: true, trim: true },
+    descripcion: { type: String, trim: true, default: "" },
+    fotos: [{ type: String }],
+    orden: { type: Number, default: 0 },
+    activo: { type: Boolean, default: true },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("productos", productoSchema);

--- a/src/models/recetas/ingrediente.js
+++ b/src/models/recetas/ingrediente.js
@@ -1,6 +1,11 @@
 const mongoose = require("mongoose");
 
 const ingredienteSchema = new mongoose.Schema({
+  insumoId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Insumos",
+    default: null,
+  },
   ingrediente: {
     type: String,
     required: true,

--- a/src/models/snackCotiza.js
+++ b/src/models/snackCotiza.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const costeoSnapshotSchema = require("./costeoSnapshot");
 
 const snacksSchema = new mongoose.Schema(
   {
@@ -101,6 +102,11 @@ const snacksSchema = new mongoose.Schema(
     },
     userId: {
       type: String,
+    },
+    images: [{ type: String }],
+    costeoSnapshot: {
+      type: costeoSnapshotSchema,
+      default: null,
     },
   },
   {

--- a/src/models/tecnicaCreativa.js
+++ b/src/models/tecnicaCreativa.js
@@ -1,0 +1,44 @@
+const mongoose = require("mongoose");
+
+const tecnicaCreativaSchema = new mongoose.Schema(
+  {
+    nombre: {
+      type: String,
+      required: [true, "El nombre de la técnica es obligatorio"],
+      trim: true,
+    },
+    categoria: {
+      type: String,
+      required: [true, "La categoría es obligatoria"],
+      enum: ["decoracion", "relleno", "cobertura", "modelado", "flores", "impresion", "otro"],
+    },
+    costoBase: {
+      type: Number,
+      required: true,
+      default: 0,
+      min: 0,
+    },
+    tiempoHoras: {
+      type: Number,
+      required: true,
+      default: 0,
+      min: 0,
+    },
+    escalaPorPorcion: {
+      type: Number,
+      default: 0,
+      min: 0,
+    },
+    descripcion: {
+      type: String,
+      trim: true,
+    },
+    activo: {
+      type: Boolean,
+      default: true,
+    },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("TecnicaCreativa", tecnicaCreativaSchema);

--- a/src/routes/costs.js
+++ b/src/routes/costs.js
@@ -66,4 +66,35 @@ router.put('/:id', checkRoleToken('admin'), async (req, res) => {
   }
 });
 
+// Obtener el único documento de costos sin conocer su ID
+router.get('/', async (req, res) => {
+  try {
+    const cost = await Cost.findOne();
+    if (!cost) return res.status(404).json({ message: "No hay costos configurados" });
+    res.json(cost);
+  } catch (error) {
+    console.error("Error obteniendo costos:", error);
+    res.status(500).json({ message: "Error al obtener los costos" });
+  }
+});
+
+// Actualizar (o crear si no existe) el único documento de costos — solo admin
+router.put('/', checkRoleToken('admin'), async (req, res) => {
+  try {
+    const { fixedCosts, laborCosts } = req.body;
+    if (fixedCosts === undefined || laborCosts === undefined) {
+      return res.status(400).json({ message: "Parámetros 'fixedCosts' y 'laborCosts' son requeridos" });
+    }
+    const cost = await Cost.findOneAndUpdate(
+      {},
+      { fixedCosts, laborCosts },
+      { upsert: true, new: true }
+    );
+    res.json(cost);
+  } catch (error) {
+    console.error("Error actualizando costos:", error);
+    res.status(500).json({ message: "Error al actualizar los costos" });
+  }
+});
+
 module.exports = router;

--- a/src/routes/cupcakesCotiza.js
+++ b/src/routes/cupcakesCotiza.js
@@ -2,6 +2,8 @@ const express = require("express");
 const router = express.Router();
 const Prices = require("../models/cupcakesCotiza");
 const checkRoleToken = require("../middlewares/myRoleToken");
+const { requireAuth } = checkRoleToken;
+const { calcularCosteo } = require("../jobs/costeoHandler");
 
 //Enviar Cotización Cupcake
 router.post("/", async (req, res) => {
@@ -16,11 +18,12 @@ router.post("/", async (req, res) => {
   }
 });
 
-//Recuperar Datos Cotización Cupcake — solo admin
-router.get("/", checkRoleToken("admin"), async (req, res) => {
+//Recuperar Datos Cotización Cupcake — admin ve todo, user solo sus propias
+router.get("/", requireAuth, async (req, res) => {
   try {
-    const pricesData = await Prices.find();
-    res.send({ message: "All Prices cupcake", data: pricesData });
+    const filter = req.user.role === "admin" ? {} : { userId: String(req.user._id) };
+    const pricesData = await Prices.find(filter);
+    res.send({ message: "All Prices cupcake", data: pricesData, total: pricesData.length });
   } catch (error) {
     res.status(400).send({ message: error });
   }
@@ -59,6 +62,24 @@ router.delete("/:id", checkRoleToken("admin"), async (req, res) => {
     res.send({ message: "Price deleted" });
   } catch (error) {
     res.status(400).send({ message: error });
+  }
+});
+
+// Calcular y guardar costeo — solo admin
+// Body: { recetaId, tecnicaIds[], margenDeseado, ivaPercent? }
+router.post("/:id/costeo", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const cotizacion = await Prices.findById(req.params.id);
+    if (!cotizacion) return res.status(404).json({ message: "Cotización no encontrada" });
+
+    const porciones = parseInt(cotizacion.portions, 10);
+    if (!porciones || porciones <= 0)
+      return res.status(400).json({ message: "La cotización no tiene porciones válidas" });
+
+    const snapshot = await calcularCosteo(cotizacion, porciones, req.body);
+    res.json({ message: "Costeo calculado", data: snapshot });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
   }
 });
 

--- a/src/routes/insumos.js
+++ b/src/routes/insumos.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const Insumos = require("../models/insumos");
+const Receta = require("../models/recetas/recetas");
 const checkRoleToken = require("../middlewares/myRoleToken");
 
 // Enviar Insumo (POST) — solo admin
@@ -49,16 +50,36 @@ router.get("/:id", async (req, res) => {
 });
 
 // Actualizar un Insumo (PUT) — solo admin
+// Tras actualizar, recalcula automáticamente el precio en todas las recetas
+// que referencian este insumo mediante insumoId.
 router.put("/:id", checkRoleToken("admin"), async (req, res) => {
   try {
     const { id } = req.params;
-    const updatedInsumo = await Insumos.findByIdAndUpdate(id, req.body, {
-      new: true,
+    const updatedInsumo = await Insumos.findByIdAndUpdate(id, req.body, { new: true });
+    if (!updatedInsumo) return res.status(404).send({ message: "Insumo not found" });
+
+    // Propagar nuevo precio a todas las recetas que usen este insumo
+    const unitCost = updatedInsumo.cost / (updatedInsumo.amount || 1);
+    const recetas = await Receta.find({ "ingredientes.insumoId": id });
+
+    await Promise.all(recetas.map(async (receta) => {
+      receta.ingredientes.forEach((ing) => {
+        if (ing.insumoId?.toString() === id) {
+          ing.precio = Math.round(unitCost * ing.cantidad * 100) / 100;
+          ing.total  = Math.round(unitCost * 100) / 100;
+        }
+      });
+      const ingTotal = receta.ingredientes.reduce((s, i) => s + (i.precio || 0), 0);
+      const rawCost  = ingTotal + (receta.additional_costs || 0);
+      receta.total_cost = Math.round((rawCost + rawCost * (receta.special_tax || 0) / 100) * 100) / 100;
+      await receta.save();
+    }));
+
+    res.status(200).send({
+      message: "Insumo updated",
+      data: updatedInsumo,
+      recetasActualizadas: recetas.length,
     });
-    if (!updatedInsumo) {
-      return res.status(404).send({ message: "Insumo not found" });
-    }
-    res.status(200).send({ message: "Insumo updated", data: updatedInsumo });
   } catch (error) {
     res.status(400).send({ message: error.message });
   }

--- a/src/routes/pastelCotiza.js
+++ b/src/routes/pastelCotiza.js
@@ -2,6 +2,8 @@ const express = require("express");
 const router = express.Router();
 const Prices = require("../models/pastelCotiza");
 const checkRoleToken = require("../middlewares/myRoleToken");
+const { requireAuth } = checkRoleToken;
+const { calcularCosteo } = require("../jobs/costeoHandler");
 
 //Enviar Cotización Cake
 router.post("/", async (req, res) => {
@@ -16,11 +18,12 @@ router.post("/", async (req, res) => {
   }
 });
 
-//Recuperar Datos Cotización Cake (listado completo) — solo admin
-router.get("/", checkRoleToken("admin"), async (req, res) => {
+//Recuperar Datos Cotización Cake — admin ve todo, user solo sus propias
+router.get("/", requireAuth, async (req, res) => {
   try {
-    const pricesData = await Prices.find();
-    res.send({ message: "All Prices Cake", data: pricesData });
+    const filter = req.user.role === "admin" ? {} : { userId: String(req.user._id) };
+    const pricesData = await Prices.find(filter);
+    res.send({ message: "All Prices Cake", data: pricesData, total: pricesData.length });
   } catch (error) {
     res.status(400).send({ message: error });
   }
@@ -69,6 +72,24 @@ router.delete("/:id", checkRoleToken("admin"), async (req, res) => {
     res.send({ message: "Price deleted" });
   } catch (error) {
     res.status(400).send({ message: error });
+  }
+});
+
+// Calcular y guardar costeo — solo admin
+// Body: { recetaId, tecnicaIds[], margenDeseado, ivaPercent? }
+router.post("/:id/costeo", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const cotizacion = await Prices.findById(req.params.id);
+    if (!cotizacion) return res.status(404).json({ message: "Cotización no encontrada" });
+
+    const porciones = parseInt(cotizacion.portions, 10);
+    if (!porciones || porciones <= 0)
+      return res.status(400).json({ message: "La cotización no tiene porciones válidas" });
+
+    const snapshot = await calcularCosteo(cotizacion, porciones, req.body);
+    res.json({ message: "Costeo calculado", data: snapshot });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
   }
 });
 

--- a/src/routes/productos.js
+++ b/src/routes/productos.js
@@ -1,0 +1,61 @@
+const express = require("express");
+const router = express.Router();
+const Producto = require("../models/producto");
+const checkRoleToken = require("../middlewares/myRoleToken");
+
+// Listar productos activos — público
+router.get("/", async (req, res) => {
+  try {
+    const filter = req.query.todos === "true" ? {} : { activo: true };
+    const productos = await Producto.find(filter).sort({ orden: 1, createdAt: 1 });
+    res.json({ message: "Productos", data: productos });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// Obtener un producto — público
+router.get("/:id", async (req, res) => {
+  try {
+    const producto = await Producto.findById(req.params.id);
+    if (!producto) return res.status(404).json({ message: "Producto no encontrado" });
+    res.json({ message: "Producto", data: producto });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// Crear producto — solo admin
+router.post("/", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const { nombre, descripcion, fotos, orden, activo } = req.body;
+    if (!nombre) return res.status(400).json({ message: "El nombre es requerido" });
+    const producto = await Producto.create({ nombre, descripcion, fotos: fotos || [], orden: orden ?? 0, activo: activo ?? true });
+    res.status(201).json({ message: "Producto creado", data: producto });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+});
+
+// Actualizar producto — solo admin
+router.put("/:id", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const producto = await Producto.findByIdAndUpdate(req.params.id, req.body, { new: true, runValidators: true });
+    if (!producto) return res.status(404).json({ message: "Producto no encontrado" });
+    res.json({ message: "Producto actualizado", data: producto });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+});
+
+// Eliminar producto — solo admin
+router.delete("/:id", checkRoleToken("admin"), async (req, res) => {
+  try {
+    await Producto.findByIdAndDelete(req.params.id);
+    res.json({ message: "Producto eliminado" });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/snackCotiza.js
+++ b/src/routes/snackCotiza.js
@@ -2,6 +2,8 @@ const express = require("express");
 const router = express.Router();
 const Prices = require("../models/snackCotiza");
 const checkRoleToken = require("../middlewares/myRoleToken");
+const { requireAuth } = checkRoleToken;
+const { calcularCosteo } = require("../jobs/costeoHandler");
 
 //Enviar Cotización Snack
 router.post("/", async (req, res) => {
@@ -15,11 +17,12 @@ router.post("/", async (req, res) => {
   }
 });
 
-//Recuperar Datos Cotización Snack — solo admin
-router.get("/", checkRoleToken("admin"), async (req, res) => {
+//Recuperar Datos Cotización Snack — admin ve todo, user solo sus propias
+router.get("/", requireAuth, async (req, res) => {
   try {
-    const pricesData = await Prices.find();
-    res.send({ message: "All Prices Snack", data: pricesData });
+    const filter = req.user.role === "admin" ? {} : { userId: String(req.user._id) };
+    const pricesData = await Prices.find(filter);
+    res.send({ message: "All Prices Snack", data: pricesData, total: pricesData.length });
   } catch (error) {
     res.status(400).send({ message: error });
   }
@@ -58,6 +61,27 @@ router.delete("/:id", checkRoleToken("admin"), async (req, res) => {
     res.send({ message: "Price deleted" });
   } catch (error) {
     res.status(400).send({ message: error });
+  }
+});
+
+// Calcular y guardar costeo — solo admin
+// Snack: porciones = people * portionsPerPerson
+// Body: { recetaId, tecnicaIds[], margenDeseado, ivaPercent? }
+router.post("/:id/costeo", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const cotizacion = await Prices.findById(req.params.id);
+    if (!cotizacion) return res.status(404).json({ message: "Cotización no encontrada" });
+
+    const people = parseInt(cotizacion.people, 10);
+    const perPerson = parseInt(cotizacion.portionsPerPerson, 10);
+    const porciones = people * perPerson;
+    if (!porciones || porciones <= 0)
+      return res.status(400).json({ message: "La cotización no tiene porciones válidas" });
+
+    const snapshot = await calcularCosteo(cotizacion, porciones, req.body);
+    res.json({ message: "Costeo calculado", data: snapshot });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
   }
 });
 

--- a/src/routes/tecnicasCreativas.js
+++ b/src/routes/tecnicasCreativas.js
@@ -1,0 +1,63 @@
+const express = require("express");
+const router = express.Router();
+const TecnicaCreativa = require("../models/tecnicaCreativa");
+const checkRoleToken = require("../middlewares/myRoleToken");
+
+// Crear técnica — solo admin
+router.post("/", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const tecnica = await TecnicaCreativa.create(req.body);
+    res.status(201).json({ message: "Técnica creada", data: tecnica });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+});
+
+// Listar técnicas activas (público) — el front las necesita al costear
+router.get("/", async (req, res) => {
+  try {
+    const filter = req.query.todas === "true" ? {} : { activo: true };
+    const tecnicas = await TecnicaCreativa.find(filter).sort({ categoria: 1, nombre: 1 });
+    res.json({ data: tecnicas });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+});
+
+// Obtener una por ID
+router.get("/:id", async (req, res) => {
+  try {
+    const tecnica = await TecnicaCreativa.findById(req.params.id);
+    if (!tecnica) return res.status(404).json({ message: "Técnica no encontrada" });
+    res.json({ data: tecnica });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+});
+
+// Actualizar — solo admin
+router.put("/:id", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const tecnica = await TecnicaCreativa.findByIdAndUpdate(req.params.id, req.body, {
+      new: true,
+      runValidators: true,
+    });
+    if (!tecnica) return res.status(404).json({ message: "Técnica no encontrada" });
+    res.json({ message: "Técnica actualizada", data: tecnica });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+});
+
+// Eliminar — solo admin
+router.delete("/:id", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const tecnica = await TecnicaCreativa.findByIdAndDelete(req.params.id);
+    if (!tecnica) return res.status(404).json({ message: "Técnica no encontrada" });
+    res.json({ message: "Técnica eliminada" });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Cambios

- `GET /costs` y `PUT /costs` sin ID hardcodeado (upsert singleton)
- Fase 2: `costeoHandler`, `costeoSnapshot`, `tecnicaCreativa`, `productos`, endpoints `/:id/costeo`
- `ingrediente.insumoId` — referencia al catálogo de insumos
- `PUT /insumos/:id` propaga automáticamente el nuevo precio a todas las recetas que usen ese insumo, y recalcula `total_cost` con la fórmula correcta (sin overhead ni margen)

## Por qué

`total_cost` en recetas ahora almacena solo el costo de materiales por lote. El overhead y el margen los aplica `costeoHandler` al momento de costear una cotización, evitando el doble conteo detectado.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)