### PR TITLE
feat(galletas): email al admin al confirmarse un pedido NY

### DIFF
--- a/src/routes/create-payment-intent/galletaEmails.js
+++ b/src/routes/create-payment-intent/galletaEmails.js
@@ -146,6 +146,101 @@ async function sendGalletaConfirmation(pedido) {
 }
 
 /**
+ * Email al admin cuando se confirma un pedido nuevo.
+ * Destinatario: ADMIN_EMAIL en .env, o EMAIL_USER por defecto.
+ */
+async function sendGalletaConfirmationToAdmin(pedido) {
+  if (!process.env.EMAIL_USER || !process.env.EMAIL_PASS) return;
+
+  const adminEmail = process.env.ADMIN_EMAIL || process.env.EMAIL_USER;
+  const transporter = buildTransporter();
+
+  const fechaTxt = formatearFechaLarga(pedido.fechaEntrega);
+  const esEnvio = pedido.tipoEntrega === "envio";
+
+  const dashboardLink = process.env.FRONT_DOMAIN
+    ? `${process.env.FRONT_DOMAIN.replace(/\/$/, "")}/dashboard/pedidos-galletas/${pedido._id}`
+    : null;
+
+  const bloqueEntrega = esEnvio
+    ? `
+        <p style="margin:0 0 4px;color:#a78891;font-size:0.78rem;text-transform:uppercase;letter-spacing:0.1em;font-weight:700;">🚚 Envío a domicilio</p>
+        <p style="margin:0;color:#540027;line-height:1.6;">${pedido.direccionEnvio.calleNumero}</p>
+        <p style="margin:0;color:#540027;line-height:1.6;">Col. ${pedido.direccionEnvio.colonia}, ${pedido.direccionEnvio.municipio}</p>
+        ${pedido.direccionEnvio.referencias ? `<p style="margin:0;color:#a78891;font-size:0.85rem;">Ref: ${pedido.direccionEnvio.referencias}</p>` : ""}
+        <p style="margin:6px 0 0;font-weight:700;color:#540027;font-size:1.05rem;">${fechaTxt} · ${pedido.horaEntrega} hrs</p>
+      `
+    : `
+        <p style="margin:0 0 4px;color:#a78891;font-size:0.78rem;text-transform:uppercase;letter-spacing:0.1em;font-weight:700;">🏪 Recogida en sucursal</p>
+        <p style="margin:6px 0 0;font-weight:700;color:#540027;font-size:1.05rem;">${fechaTxt} · ${pedido.horaEntrega} hrs</p>
+      `;
+
+  const html = `
+    <div style="font-family:Arial,sans-serif;max-width:560px;margin:0 auto;background:#fff;border:1px solid #ffe2e7;border-radius:14px;overflow:hidden;">
+      <div style="background:linear-gradient(135deg,#540027,#7A1F44);padding:24px;text-align:center;">
+        <p style="margin:0 0 4px;color:#FFC3C9;font-size:0.7rem;font-weight:700;text-transform:uppercase;letter-spacing:0.16em;">🍪 Galletas NY · Nuevo pedido</p>
+        <h1 style="margin:0;color:#fff;font-size:1.6rem;">Pedido confirmado · $${pedido.total}</h1>
+      </div>
+
+      <div style="padding:24px;">
+        <div style="background:#fff1f2;border-left:4px solid #FF6F7D;border-radius:8px;padding:14px 16px;margin-bottom:18px;">
+          <p style="margin:0;color:#a78891;font-size:0.78rem;text-transform:uppercase;letter-spacing:0.1em;font-weight:700;">Número de orden</p>
+          <p style="margin:4px 0 0;font-size:1.4rem;font-weight:800;color:#540027;font-family:'Courier New',monospace;letter-spacing:0.04em;">${pedido.numeroOrden}</p>
+        </div>
+
+        <h3 style="color:#540027;font-size:1rem;margin:0 0 10px;">Cliente</h3>
+        <div style="background:#fff;border:1px solid #ffe2e7;border-radius:10px;padding:14px 16px;margin-bottom:18px;">
+          <p style="margin:0 0 4px;color:#540027;font-weight:700;font-size:1.05rem;">${pedido.cliente.nombre}</p>
+          <p style="margin:0;color:#540027;line-height:1.7;font-size:0.9rem;">
+            📞 <a href="tel:${pedido.cliente.telefono}" style="color:#540027;text-decoration:none;">${pedido.cliente.telefono}</a>
+          </p>
+          <p style="margin:0;color:#540027;line-height:1.7;font-size:0.9rem;">
+            ✉️ <a href="mailto:${pedido.cliente.email}" style="color:#540027;text-decoration:none;">${pedido.cliente.email}</a>
+          </p>
+        </div>
+
+        <h3 style="color:#540027;font-size:1rem;margin:0 0 10px;">Detalle del pedido</h3>
+        ${renderCajas(pedido.cajas)}
+
+        <table style="width:100%;border-collapse:collapse;margin-top:14px;">
+          <tr><td style="padding:4px 0;color:#a78891;">Subtotal galletas</td><td style="padding:4px 0;text-align:right;color:#540027;font-weight:600;">$${pedido.subtotalProductos}</td></tr>
+          ${pedido.costoEnvio > 0 ? `<tr><td style="padding:4px 0;color:#a78891;">Envío</td><td style="padding:4px 0;text-align:right;color:#540027;font-weight:600;">$${pedido.costoEnvio}</td></tr>` : ""}
+          <tr><td style="padding:8px 0;border-top:2px solid #ffe2e7;color:#540027;font-weight:800;">Total cobrado</td><td style="padding:8px 0;border-top:2px solid #ffe2e7;text-align:right;color:#540027;font-weight:800;font-size:1.15rem;">$${pedido.total}</td></tr>
+        </table>
+
+        <h3 style="color:#540027;font-size:1rem;margin:24px 0 10px;">Entrega</h3>
+        <div style="background:#fff;border:1px solid #ffe2e7;border-radius:10px;padding:14px 16px;margin-bottom:18px;">
+          ${bloqueEntrega}
+        </div>
+
+        ${pedido.notas ? `<div style="background:#FFE99B;border-radius:8px;padding:10px 14px;margin-bottom:18px;"><p style="margin:0;color:#6B4F1A;font-size:0.85rem;"><strong>Nota del cliente:</strong> ${pedido.notas}</p></div>` : ""}
+
+        ${dashboardLink ? `
+          <div style="text-align:center;margin:24px 0 8px;">
+            <a href="${dashboardLink}" style="display:inline-block;padding:12px 26px;background:#540027;color:#fff;text-decoration:none;border-radius:999px;font-weight:700;font-size:0.9rem;">
+              Ver pedido en el dashboard →
+            </a>
+          </div>
+        ` : ""}
+
+        <p style="margin:18px 0 0;color:#a78891;font-size:0.78rem;text-align:center;line-height:1.6;">
+          Notificación automática · Pastelería El Ruiseñor
+        </p>
+      </div>
+    </div>
+  `;
+
+  await transporter.sendMail({
+    from: `"Pastelería El Ruiseñor" <${process.env.EMAIL_USER}>`,
+    to: adminEmail,
+    subject: `🍪 Nuevo pedido NY · ${pedido.numeroOrden} · $${pedido.total}`,
+    html,
+  });
+
+  console.log(`[galletaEmails] aviso admin enviado a ${adminEmail} (${pedido.numeroOrden})`);
+}
+
+/**
  * Aviso interno al admin cuando uno o más sabores quedan en stock bajo (< 6).
  * El destinatario es ADMIN_EMAIL en .env, o EMAIL_USER por defecto.
  */
@@ -183,5 +278,6 @@ async function sendLowStockAlert(saboresBajos) {
 
 module.exports = {
   sendGalletaConfirmation,
+  sendGalletaConfirmationToAdmin,
   sendLowStockAlert,
 };

--- a/src/routes/create-payment-intent/webhook.js
+++ b/src/routes/create-payment-intent/webhook.js
@@ -9,7 +9,7 @@ const Cupcake = require("../../models/cupcakesCotiza");
 const Snack = require("../../models/snackCotiza");
 const GalletaPedido = require("../../models/galletaPedido");
 const GalletaSabor  = require("../../models/galletaSabor");
-const { sendGalletaConfirmation, sendLowStockAlert } = require("./galletaEmails");
+const { sendGalletaConfirmation, sendGalletaConfirmationToAdmin, sendLowStockAlert } = require("./galletaEmails");
 const { createGalletaEvent } = require("../../utils/googleCalendar");
 
 /**
@@ -231,6 +231,13 @@ async function procesarPedidoGalleta(session, finalStatus) {
     await sendGalletaConfirmation(pedido);
   } catch (e) {
     console.error("[webhook galleta] error enviando email confirmación:", e.message);
+  }
+
+  // ── Email de aviso al admin (no bloquea si falla) ──
+  try {
+    await sendGalletaConfirmationToAdmin(pedido);
+  } catch (e) {
+    console.error("[webhook galleta] error enviando aviso al admin:", e.message);
   }
 
   // ── Crear evento en Google Calendar de la pastelería ──


### PR DESCRIPTION
## Summary

Cuando el webhook de Stripe marca un pedido de Galletas NY como `paid`, ahora se envía un correo paralelo al admin con el detalle completo del pedido — además del correo que ya recibe el cliente.

## Cambios

### `src/routes/create-payment-intent/galletaEmails.js`
Nueva función `sendGalletaConfirmationToAdmin(pedido)`:
- Destinatario: \`ADMIN_EMAIL\` en .env si está configurado; fallback a \`EMAIL_USER\` (mismo patrón que `sendLowStockAlert`)
- Asunto: \`🍪 Nuevo pedido NY · {numeroOrden} · ${total}\`
- HTML incluye:
  - Número de orden destacado
  - **Cliente**: nombre + teléfono clickable (\`tel:\`) + email clickable (\`mailto:\`)
  - Detalle de cajas (reutiliza `renderCajas`)
  - Subtotales y total cobrado
  - **Entrega**: tipo (🚚 envío / 🏪 recogida) + fecha legible + hora + dirección si aplica
  - Notas del cliente si las hay
  - Botón con link al detalle del pedido en el dashboard admin (usa \`FRONT_DOMAIN\`)

### `src/routes/create-payment-intent/webhook.js`
- Import actualizado: `sendGalletaConfirmationToAdmin`
- Llamada agregada en `procesarPedidoGalleta` justo después del email al cliente, dentro de su propio try/catch para que un fallo no bloquee el resto del webhook (igual que ya se hace con el email del cliente y el evento de Calendar).

## Config

Sin cambios obligatorios — la nueva variable `ADMIN_EMAIL` es opcional:
- Si la defines: recibe ahí los avisos (admin separado del remitente)
- Si no la defines: recibe en `EMAIL_USER` (mismo correo desde el que se envía)

## Smoke test local

- [x] `node --check` OK en ambos archivos
- [x] Mock de `nodemailer` → la función ejecuta, arma subject y HTML válido (4720 chars), llama `sendMail` con destinatario correcto
- [x] Subject formateado: \`🍪 Nuevo pedido NY · NY-2026-0042 · $498\`

## Test plan en preview

- [ ] Hacer un pedido de prueba en /enduser/galletas-checkout con Stripe en modo test (\`4242 4242 4242 4242\`)
- [ ] Completar el pago → esperar webhook
- [ ] Verificar que `EMAIL_USER`/`ADMIN_EMAIL` recibe el correo con asunto \`🍪 Nuevo pedido NY · …\`
- [ ] Verificar que el link al dashboard apunta a `/dashboard/pedidos-galletas/{id}` y abre correcto
- [ ] Verificar que el correo del **cliente** sigue llegando como antes (no regresión)
- [ ] Probar pedido con **envío** y con **recogida** — el bloque de entrega debe verse distinto en cada uno
- [ ] Probar pedido **con notas** y sin notas — bloque amarillo solo aparece si hay notas

🤖 Generated with [Claude Code](https://claude.com/claude-code)