### PR TITLE
feat(galletas): precio sugerido desde receta + alerta de margen bajo

### DIFF
--- a/src/models/costs.js
+++ b/src/models/costs.js
@@ -9,6 +9,27 @@ const costSchema = new mongoose.Schema({
     type: Number,
     required: true,
   },
+
+  // ── Galletas NY: configuración global ──────────────────────────
+  // Se inyectan en el cálculo de precio sugerido al dar de alta un sabor.
+  // Defaults pensados para que el sistema funcione aunque el admin no
+  // haya configurado nada todavía: costo cero, markup 60%, margen mínimo
+  // de $5 por galleta antes de levantar alerta de margen bajo.
+  costoBrandingPorGalleta: {
+    type: Number,
+    default: 0,
+    min: 0,
+  },
+  markupGalletasPct: {
+    type: Number,
+    default: 60,
+    min: 0,
+  },
+  margenMinimoGalleta: {
+    type: Number,
+    default: 5,
+    min: 0,
+  },
 });
 
 module.exports = mongoose.model("Cost", costSchema);

--- a/src/models/galletaSabor.js
+++ b/src/models/galletaSabor.js
@@ -55,6 +55,25 @@ const galletaSaborSchema = new mongoose.Schema(
     activo:      { type: Boolean, default: true },   // Soft-delete: false oculta del catálogo
 
     orden: { type: Number, default: 0 },              // Para ordenar en el frontend
+
+    // ── Costeo desde receta (opcional, retrocompatible) ──────────
+    // Si `recetaId` está presente, el sabor "hereda" su costo unitario
+    // del cálculo de la receta. El `costoUnitarioSnapshot` se congela
+    // al crear o al usar `POST /galletas-ny/sabores/:id/recostear` —
+    // así el precio mostrado al cliente no cambia si suben los insumos,
+    // pero el sistema vigila el costo "live" y avisa cuando el margen
+    // (precio − costoLive) cae por debajo de `Cost.margenMinimoGalleta`.
+    recetaId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Receta",
+      default: null,
+    },
+    costoUnitarioSnapshot: {
+      type: Number,
+      default: null,
+      min: 0,
+    },
+    fechaCosteoSnapshot: { type: Date, default: null },
   },
   { timestamps: true }
 );

--- a/src/routes/costs.js
+++ b/src/routes/costs.js
@@ -78,16 +78,28 @@ router.get('/', async (req, res) => {
   }
 });
 
-// Actualizar (o crear si no existe) el único documento de costos — solo admin
+// Actualizar (o crear si no existe) el único documento de costos — solo admin.
+// `fixedCosts` y `laborCosts` siguen siendo requeridos (compat con el form
+// existente de gastosfijosymanodeobra). Los 3 campos de galletas
+// (`costoBrandingPorGalleta`, `markupGalletasPct`, `margenMinimoGalleta`)
+// son opcionales — solo se actualizan si vienen en el body. Esto permite
+// que el front mande payloads parciales sin pisar valores existentes.
 router.put('/', checkRoleToken('admin'), async (req, res) => {
   try {
-    const { fixedCosts, laborCosts } = req.body;
+    const {
+      fixedCosts, laborCosts,
+      costoBrandingPorGalleta, markupGalletasPct, margenMinimoGalleta,
+    } = req.body;
     if (fixedCosts === undefined || laborCosts === undefined) {
       return res.status(400).json({ message: "Parámetros 'fixedCosts' y 'laborCosts' son requeridos" });
     }
+    const update = { fixedCosts, laborCosts };
+    if (costoBrandingPorGalleta !== undefined) update.costoBrandingPorGalleta = costoBrandingPorGalleta;
+    if (markupGalletasPct       !== undefined) update.markupGalletasPct       = markupGalletasPct;
+    if (margenMinimoGalleta     !== undefined) update.margenMinimoGalleta     = margenMinimoGalleta;
     const cost = await Cost.findOneAndUpdate(
       {},
-      { fixedCosts, laborCosts },
+      update,
       { upsert: true, new: true }
     );
     res.json(cost);

--- a/src/routes/galletaSabores.js
+++ b/src/routes/galletaSabores.js
@@ -1,6 +1,9 @@
 const express = require("express");
 const router = express.Router();
 const GalletaSabor = require("../models/galletaSabor");
+const Receta = require("../models/recetas/recetas");
+const Cost = require("../models/costs");
+const Notificacion = require("../models/notificaciones");
 const checkRoleToken = require("../middlewares/myRoleToken");
 
 /**
@@ -10,16 +13,133 @@ const checkRoleToken = require("../middlewares/myRoleToken");
  * catálogo sin autenticación). Mutaciones solo admin.
  */
 
+// ── Helpers de costeo ───────────────────────────────────────────────
+
+/**
+ * Lee la config global de costeo de galletas. Si no existe documento
+ * `Cost`, devuelve defaults seguros para que el cálculo no falle al
+ * principio (cuando el admin no ha capturado nada todavía).
+ */
+async function getGalletaCostConfig() {
+  const cfg = await Cost.findOne();
+  return {
+    costoBranding:  cfg?.costoBrandingPorGalleta ?? 0,
+    markupPct:      cfg?.markupGalletasPct ?? 60,
+    margenMinimo:   cfg?.margenMinimoGalleta ?? 5,
+  };
+}
+
+/**
+ * Costo "live" por galleta a partir de la receta + config global.
+ * Devuelve null si no se puede calcular (sin receta o sin porciones).
+ */
+function calcularCostoLive(receta, costoBranding) {
+  if (!receta || !receta.portions || receta.portions <= 0) return null;
+  if (typeof receta.total_cost !== "number") return null;
+  const costoMP = receta.total_cost / receta.portions;
+  return Math.round((costoMP + costoBranding) * 100) / 100;
+}
+
+/**
+ * Crea una notificación de margen bajo si no hay otra reciente (30 días)
+ * para el mismo sabor. Idempotente: evita spamear al admin.
+ */
+async function notificarMargenBajoSiCorresponde(sabor, margenActual, margenMinimo) {
+  const treintaDiasAtras = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  const yaNotificado = await Notificacion.findOne({
+    mensaje: { $regex: `Margen bajo · ${sabor.slug}`, $options: "i" },
+    fecha: { $gte: treintaDiasAtras },
+  });
+  if (yaNotificado) return;
+
+  await Notificacion.create({
+    mensaje: `⚠️ Margen bajo · ${sabor.nombre} (${sabor.slug}): margen actual $${margenActual.toFixed(2)} (mínimo $${margenMinimo}). Considera recostear o subir precio.`,
+    userId: "admin",
+  });
+}
+
 // ── GET /galletaSabores — listar sabores ────────────────────────────
 // Público. Por defecto solo devuelve activos. Admin puede pasar ?todos=true.
+// Si ?conMargen=true se calcula `costoLive`, `margenActual` y
+// `alertaMargenBajo` para cada sabor con receta — solo recomendable
+// para el listado del admin (requiere JOIN con recetas y config).
 router.get("/", async (req, res) => {
   try {
     const filter = req.query.todos === "true" ? {} : { activo: true };
     const sabores = await GalletaSabor.find(filter).sort({ orden: 1, createdAt: 1 });
-    res.json({ message: "Sabores de galleta", data: sabores });
+
+    if (req.query.conMargen !== "true") {
+      return res.json({ message: "Sabores de galleta", data: sabores });
+    }
+
+    // Modo admin con vigilancia de margen.
+    const { costoBranding, margenMinimo } = await getGalletaCostConfig();
+    const recetaIds = [...new Set(sabores.map(s => s.recetaId).filter(Boolean).map(String))];
+    const recetas = recetaIds.length
+      ? await Receta.find({ _id: { $in: recetaIds } }).select("nombre_receta total_cost portions")
+      : [];
+    const recetaMap = new Map(recetas.map(r => [String(r._id), r]));
+
+    const enriched = await Promise.all(sabores.map(async (s) => {
+      const obj = s.toObject({ virtuals: true });
+      if (!s.recetaId) return obj;
+      const receta = recetaMap.get(String(s.recetaId));
+      const costoLive = calcularCostoLive(receta, costoBranding);
+      if (costoLive == null) return obj;
+      const margenActual = Math.round((s.precio - costoLive) * 100) / 100;
+      const alerta = margenActual < margenMinimo;
+      if (alerta) {
+        // Side-effect: notifica al admin (idempotente). No bloqueamos
+        // la respuesta si esto falla.
+        notificarMargenBajoSiCorresponde(s, margenActual, margenMinimo).catch(e =>
+          console.error("[galletaSabores] error creando notificación margen bajo:", e.message)
+        );
+      }
+      return { ...obj, costoLive, margenActual, alertaMargenBajo: alerta };
+    }));
+
+    res.json({ message: "Sabores de galleta", data: enriched });
   } catch (error) {
     console.error("Error listando sabores galletas:", error);
     res.status(500).json({ message: error.message });
+  }
+});
+
+// ── POST /galletaSabores/calcular-precio (admin) ────────────────────
+// Devuelve un breakdown sugerido para un sabor a partir de una receta
+// + la config global de branding y markup. NO modifica nada.
+// Body: { recetaId, markupPct? }
+router.post("/calcular-precio", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const { recetaId, markupPct } = req.body || {};
+    if (!recetaId) return res.status(400).json({ message: "recetaId es requerido" });
+
+    const receta = await Receta.findById(recetaId);
+    if (!receta) return res.status(404).json({ message: "Receta no encontrada" });
+    if (!receta.portions || receta.portions <= 0) {
+      return res.status(400).json({ message: "La receta no tiene `portions` válido" });
+    }
+
+    const { costoBranding, markupPct: markupDefault } = await getGalletaCostConfig();
+    const markup = typeof markupPct === "number" && markupPct >= 0 ? markupPct : markupDefault;
+
+    const costoMateriaPrima = Math.round((receta.total_cost / receta.portions) * 100) / 100;
+    const costoTotal = Math.round((costoMateriaPrima + costoBranding) * 100) / 100;
+    const precioSugerido = Math.round(costoTotal * (1 + markup / 100) * 100) / 100;
+
+    res.json({
+      message: "Precio calculado",
+      data: {
+        receta: { _id: receta._id, nombre_receta: receta.nombre_receta, portions: receta.portions, total_cost: receta.total_cost },
+        costoMateriaPrima,
+        costoBranding,
+        costoTotal,
+        markupPct: markup,
+        precioSugerido,
+      },
+    });
+  } catch (error) {
+    res.status(400).json({ message: error.message });
   }
 });
 
@@ -36,16 +156,34 @@ router.get("/:id", async (req, res) => {
 
 // ── POST /galletaSabores — crear sabor (admin) ──────────────────────
 // Toma slug, nombre, precio, stock inicial y opcionalmente imagen/tags.
+// Opcionalmente acepta `recetaId` — si está, el sistema congela el
+// costo unitario actual de esa receta como `costoUnitarioSnapshot`.
+// El admin puede haber visto el precio sugerido vía `/calcular-precio`
+// y ajustar `precio` antes de mandar el POST.
 router.post("/", checkRoleToken("admin"), async (req, res) => {
   try {
     const {
       slug, nombre, descripcion, precio, stock,
       imagen, emoji, bg, tag, tagColor, tagText,
       esTemporada, activo, orden,
+      recetaId,
     } = req.body;
 
     if (!slug || !nombre || precio == null) {
       return res.status(400).json({ message: "slug, nombre y precio son requeridos" });
+    }
+
+    let costoUnitarioSnapshot = null;
+    let fechaCosteoSnapshot = null;
+    if (recetaId) {
+      const receta = await Receta.findById(recetaId);
+      if (!receta) return res.status(404).json({ message: "Receta no encontrada" });
+      const { costoBranding } = await getGalletaCostConfig();
+      const live = calcularCostoLive(receta, costoBranding);
+      if (live != null) {
+        costoUnitarioSnapshot = live;
+        fechaCosteoSnapshot = new Date();
+      }
     }
 
     const sabor = await GalletaSabor.create({
@@ -63,6 +201,9 @@ router.post("/", checkRoleToken("admin"), async (req, res) => {
       esTemporada: !!esTemporada,
       activo:      activo !== false,
       orden:       Number(orden) || 0,
+      recetaId:    recetaId || null,
+      costoUnitarioSnapshot,
+      fechaCosteoSnapshot,
     });
 
     res.status(201).json({ message: "Sabor creado", data: sabor });
@@ -70,6 +211,38 @@ router.post("/", checkRoleToken("admin"), async (req, res) => {
     if (error.code === 11000) {
       return res.status(409).json({ message: "Ya existe un sabor con ese slug" });
     }
+    res.status(400).json({ message: error.message });
+  }
+});
+
+// ── POST /galletaSabores/:id/recostear (admin) ──────────────────────
+// Refresca el snapshot del sabor con el costo "live" actual de su
+// receta. Útil cuando suben los precios de insumos y el admin quiere
+// reflejar el nuevo costo (sin tocar el precio mostrado al cliente —
+// eso lo decide el admin aparte).
+router.post("/:id/recostear", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const sabor = await GalletaSabor.findById(req.params.id);
+    if (!sabor) return res.status(404).json({ message: "Sabor no encontrado" });
+    if (!sabor.recetaId) {
+      return res.status(400).json({ message: "Este sabor no tiene receta asociada — no se puede recostear" });
+    }
+
+    const receta = await Receta.findById(sabor.recetaId);
+    if (!receta) return res.status(404).json({ message: "Receta asociada no encontrada" });
+
+    const { costoBranding } = await getGalletaCostConfig();
+    const live = calcularCostoLive(receta, costoBranding);
+    if (live == null) {
+      return res.status(400).json({ message: "No se pudo calcular el costo (receta sin porciones o total_cost)" });
+    }
+
+    sabor.costoUnitarioSnapshot = live;
+    sabor.fechaCosteoSnapshot = new Date();
+    await sabor.save();
+
+    res.json({ message: "Costo del sabor actualizado", data: sabor });
+  } catch (error) {
     res.status(400).json({ message: error.message });
   }
 });


### PR DESCRIPTION
## Summary

**PR back** de una feature en 2 partes (PR front llega aparte). Permite al admin "heredar" el costo de un sabor de Galleta NY desde una receta existente en lugar de capturar el precio manualmente, y vigila automáticamente cuando los costos suben.

## Flujo de usuario (target)

1. Admin da de alta nuevo sabor → elige receta del dropdown
2. Sistema calcula breakdown: `costoMateriaPrima + costoBranding = costoTotal` y propone `precioSugerido = costoTotal * (1 + markup%)`
3. Admin ve el breakdown, ajusta el precio si quiere y guarda
4. Sistema congela `costoUnitarioSnapshot` — el precio mostrado al cliente NO cambia aunque suban los insumos después
5. En segundo plano, cada vez que el admin lista los sabores con `?conMargen=true`, el sistema:
   - Recalcula el costo "live" desde la receta actual
   - Si `precio - costoLive < margenMinimoGalleta` (default $5) → marca el sabor con `alertaMargenBajo: true` y crea una notificación interna (máx 1 cada 30 días por sabor)

## Cambios

### `models/costs.js` — config global de galletas
3 campos opcionales (no rompen los `fixedCosts` y `laborCosts` requeridos existentes):
- `costoBrandingPorGalleta` (default 0)
- `markupGalletasPct` (default 60)
- `margenMinimoGalleta` (default 5)

### `models/galletaSabor.js` — campos de costeo
3 campos opcionales, retrocompatibles (sabores existentes siguen funcionando):
- `recetaId` (ref \`Receta\`, opcional)
- `costoUnitarioSnapshot` (Number, congelado al crear/recostear)
- `fechaCosteoSnapshot` (Date)

### `routes/galletaSabores.js`
- **`GET /`** con `?conMargen=true` enriquece cada sabor con \`{ costoLive, margenActual, alertaMargenBajo }\`. Sin el flag se comporta igual que antes (público).
- **`POST /calcular-precio`** (admin) — preview sin escribir nada.
  - Body: \`{ recetaId, markupPct? }\`
  - Response: \`{ costoMateriaPrima, costoBranding, costoTotal, markupPct, precioSugerido, receta }\`
- **`POST /:id/recostear`** (admin) — refresca el snapshot al costo actual de la receta asociada.
- **`POST /`** acepta \`recetaId\` opcional. Si está, congela el snapshot al crear.

## Smoke tests locales

| Caso | Esperado | OK |
|---|---|---|
| Receta 50 galletas, \$500 + \$3 branding | costoLive = \$13 | ✅ |
| Markup 60% sobre \$13 | precioSugerido = \$20.80 | ✅ |
| Receta sin porciones | null | ✅ |
| Receta null | null | ✅ |
| `node --check` en los 3 archivos | OK | ✅ |
| `require('./routes/galletaSabores')` | 8 endpoints registrados | ✅ |

## Compatibilidad

- **Sin migración requerida**: todos los campos nuevos son opcionales con defaults razonables. Los sabores existentes con \`recetaId: null\` siguen mostrando su \`precio\` manual y NO disparan alertas.
- **Si no existe documento `Cost`** (admin nuevo): los helpers usan defaults seguros (branding 0, markup 60, margen 5) — el cálculo funciona desde el primer día.

## Out of scope

- Frontend (PR aparte): dropdown de receta en el form, breakdown visual, highlight en listado, sección de config en gastosfijos.
- Migración masiva de sabores existentes: el admin puede asociarles receta uno por uno con el form de edición.
- Cron de checkeo proactivo: por ahora el check es lazy (al listar). Si más adelante hay 100+ sabores migrar a cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)