### PR TITLE
fix(insumos): permitir espacios, acentos y números en nombre y unidad

### DIFF
--- a/src/models/insumos.js
+++ b/src/models/insumos.js
@@ -1,26 +1,43 @@
 const mongoose = require("mongoose");
 
+/**
+ * Insumo / materia prima.
+ *
+ * El `name` y `unit` antes tenían un regex `/^[A-Za-z]+$/` que rechazaba
+ * cualquier nombre con espacios, acentos, números o porcentajes — eso
+ * bloqueaba ingredientes legítimos como "Nuez de Macadamia", "Plátano",
+ * "Chocolate 70%" o "Harina 000". El regex está fuera; en su lugar
+ * limitamos por longitud y dejamos pasar nombres naturales.
+ *
+ * `amount` y `cost` son Number, así que el `match: [regex]` anterior era
+ * código muerto (Mongoose solo evalúa regex en Strings). Se reemplaza
+ * por `min: 0` que sí valida.
+ */
 const insumosSchema = new mongoose.Schema(
   {
     name: {
       type: String,
-      required: true,
-      match: [/^[A-Za-z]+$/, "Character not valid"],
+      required: [true, "El nombre es obligatorio"],
+      trim: true,
+      minlength: [1, "El nombre no puede estar vacío"],
+      maxlength: [100, "El nombre es demasiado largo (máx 100 caracteres)"],
     },
     amount: {
       type: Number,
-      required: true,
-      match: [/^[0-9]+$/, "character not valid"],
+      required: [true, "La cantidad es obligatoria"],
+      min: [0, "La cantidad no puede ser negativa"],
     },
     cost: {
       type: Number,
-      required: true,
-      match: [/^[0-9]+$/, "character not valid"],
+      required: [true, "El costo es obligatorio"],
+      min: [0, "El costo no puede ser negativo"],
     },
     unit: {
       type: String,
-      required: true,
-      match: [/^[A-Za-z]+$/, "Character not valid"],
+      required: [true, "La unidad es obligatoria"],
+      trim: true,
+      minlength: [1, "La unidad no puede estar vacía"],
+      maxlength: [20, "La unidad es demasiado larga (máx 20 caracteres)"],
     },
   },
   {


### PR DESCRIPTION
## Summary

**Bug reportado por Alberto:** al agregar el insumo "Nuez de Macadamia" sale el error:

> Error: insumos validation failed: name: Character not valid

## Causa raíz

En \`src/models/insumos.js\` la validación de \`name\` y \`unit\` usaba el regex \`/^[A-Za-z]+$/\` que **rechaza espacios, acentos, números y porcentajes**. Bloquea ingredientes legítimos como:

- \"Nuez de Macadamia\" → espacios
- \"Plátano\", \"Almíbar\" → acentos
- \"Chocolate 70%\" → número + %
- \"Harina 000\" → números

Además, los campos \`amount\` y \`cost\` (tipo \`Number\`) tenían \`match: [/^[0-9]+$/]\` que es **código muerto** — Mongoose solo evalúa regex en Strings, no en Numbers.

## Fix

- **\`name\`**: regex fuera; \`trim\` + \`minlength: 1\` + \`maxlength: 100\`.
- **\`unit\`**: regex fuera; \`trim\` + \`minlength: 1\` + \`maxlength: 20\`.
- **\`amount\`** / **\`cost\`**: regex muerto reemplazado por \`min: 0\` (que sí valida).
- Mensajes de error en español, alineados con el resto del modelo.

## Smoke test local

| Caso | Resultado |
|---|---|
| \"Nuez de Macadamia\" / 50 gr / \$250 | ✅ OK |
| \"Plátano\" / 1 pza / \$5 | ✅ OK |
| \"Chocolate 70%\" / 200 gr / \$80 | ✅ OK |
| \"Harina 000\" / 1 kg / \$35 | ✅ OK |
| \"Almíbar Maple\" / 250 ml / \$150 | ✅ OK |
| nombre vacío | ❌ Rechazado correctamente |
| nombre de 101 chars | ❌ Rechazado correctamente |
| amount negativo | ❌ Rechazado correctamente |

## Test plan en preview

- [ ] Ir a \`/dashboard/insumosytrabajomanual/agregarinsumosotrabajo\`
- [ ] Agregar \"Nuez de Macadamia\" — debe guardarse sin error
- [ ] Agregar \"Chocolate 70%\" — debe guardarse
- [ ] Intentar guardar nombre vacío — debe mostrar mensaje de error claro

## Out of scope

Hay regex similares (igualmente código muerto sobre tipos Number) en \`src/models/recetas/recetas.js\` (\`profit_margin\`, \`portions\`, \`fixed_costs_hours\`, \`total_cost\`). No los toco aquí para mantener el PR enfocado en el bug reportado; si quieres los limpio aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)