### PR TITLE
feat(insumos): bloquear duplicados + autocomplete + script de migración

### DIFF
--- a/scripts/dedupe-insumos.js
+++ b/scripts/dedupe-insumos.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+require("dotenv").config();
+const mongoose = require("mongoose");
+const Insumos = require("../src/models/insumos");
+const Receta = require("../src/models/recetas/recetas");
+const { normalizeName } = require("../src/utils/normalizeName");
+
+/**
+ * Detecta y opcionalmente fusiona insumos duplicados por nombre normalizado.
+ *
+ * Sin flags es DRY-RUN: solo reporta los grupos de duplicados detectados.
+ * Con `--apply` ejecuta la fusión:
+ *   1. Elige un insumo canónico del grupo (por defecto el más antiguo).
+ *   2. En todas las recetas que referencian a los otros duplicados,
+ *      reescribe `ingredientes.insumoId` al canónico.
+ *   3. Borra los duplicados.
+ *
+ * Criterio de canónico:
+ *   --canonical=oldest   (default) el `createdAt` más viejo
+ *   --canonical=newest   el `createdAt` más reciente
+ *   --canonical=cheapest el de menor `cost` (útil si el precio histórico
+ *                         es el "correcto" — usar con cuidado)
+ *
+ * Uso:
+ *   node scripts/dedupe-insumos.js                  # dry-run, oldest
+ *   node scripts/dedupe-insumos.js --apply           # aplica con oldest
+ *   node scripts/dedupe-insumos.js --apply --canonical=newest
+ *
+ * IMPORTANTE: hacer backup de la DB antes de correr con --apply.
+ * El script imprime el plan completo en dry-run para que puedas revisarlo.
+ */
+
+function parseArgs(argv) {
+  const out = { apply: false, canonical: "oldest" };
+  for (const arg of argv.slice(2)) {
+    if (arg === "--apply") { out.apply = true; continue; }
+    const m = arg.match(/^--([^=]+)=(.*)$/);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+function pickCanonical(group, strategy) {
+  const sorted = [...group];
+  if (strategy === "newest") {
+    sorted.sort((a, b) => (b.createdAt?.getTime() || 0) - (a.createdAt?.getTime() || 0));
+  } else if (strategy === "cheapest") {
+    sorted.sort((a, b) => (a.cost ?? Infinity) - (b.cost ?? Infinity));
+  } else {
+    // oldest (default)
+    sorted.sort((a, b) => (a.createdAt?.getTime() || 0) - (b.createdAt?.getTime() || 0));
+  }
+  return sorted[0];
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (!process.env.MONGO_URL) {
+    console.error("MONGO_URL no está definida en .env");
+    process.exit(1);
+  }
+
+  await mongoose.connect(process.env.MONGO_URL);
+  console.log(`Conectado a Mongo. Modo: ${args.apply ? "APPLY" : "DRY-RUN"}. Canónico: ${args.canonical}`);
+
+  // 1) Backfill: asegurar que todos los insumos tengan nameNormalized.
+  // Solo escribimos a los que les falta — barato.
+  const sinNorm = await Insumos.find({ $or: [{ nameNormalized: { $exists: false } }, { nameNormalized: "" }, { nameNormalized: null }] });
+  if (sinNorm.length) {
+    console.log(`\nBackfilling nameNormalized en ${sinNorm.length} insumos…`);
+    for (const i of sinNorm) {
+      i.nameNormalized = normalizeName(i.name);
+      if (args.apply) await i.save();
+    }
+  }
+
+  // 2) Detectar grupos duplicados.
+  const all = await Insumos.find({}).sort({ createdAt: 1 });
+  const groups = new Map();
+  for (const i of all) {
+    const key = i.nameNormalized || normalizeName(i.name);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(i);
+  }
+  const dups = [...groups.entries()].filter(([, arr]) => arr.length > 1);
+
+  if (!dups.length) {
+    console.log("\n✅ No se detectaron duplicados.");
+    await mongoose.disconnect();
+    return;
+  }
+
+  console.log(`\n⚠️  ${dups.length} grupos de duplicados detectados:\n`);
+
+  let totalAEliminar = 0;
+  let totalRecetasAfectadas = 0;
+
+  for (const [key, group] of dups) {
+    const canonical = pickCanonical(group, args.canonical);
+    const others = group.filter(i => String(i._id) !== String(canonical._id));
+    const otherIds = others.map(i => i._id);
+
+    // Recetas que referencian a los duplicados (no al canónico)
+    const recetas = await Receta.find({ "ingredientes.insumoId": { $in: otherIds } });
+
+    console.log(`▸ "${key}" (${group.length} duplicados):`);
+    console.log(`   ✓ CANÓNICO: ${canonical._id} · "${canonical.name}" · $${canonical.cost} / ${canonical.amount} ${canonical.unit} · created ${canonical.createdAt?.toISOString().slice(0,10)}`);
+    for (const o of others) {
+      console.log(`   ✗ DUPLICADO: ${o._id} · "${o.name}" · $${o.cost} / ${o.amount} ${o.unit} · created ${o.createdAt?.toISOString().slice(0,10)}`);
+    }
+    if (recetas.length) {
+      console.log(`   → ${recetas.length} receta(s) referencian a duplicado(s): ${recetas.map(r => r.nombre_receta).join(", ")}`);
+    } else {
+      console.log(`   → ninguna receta usa los duplicados (borrado limpio)`);
+    }
+    console.log("");
+
+    totalAEliminar += others.length;
+    totalRecetasAfectadas += recetas.length;
+
+    if (args.apply) {
+      // Reescribe referencias en recetas
+      for (const receta of recetas) {
+        receta.ingredientes.forEach(ing => {
+          if (ing.insumoId && otherIds.some(id => String(id) === String(ing.insumoId))) {
+            ing.insumoId = canonical._id;
+          }
+        });
+        await receta.save();
+      }
+      // Borra duplicados
+      await Insumos.deleteMany({ _id: { $in: otherIds } });
+    }
+  }
+
+  console.log(`\nResumen:`);
+  console.log(`  - Grupos con duplicados: ${dups.length}`);
+  console.log(`  - Insumos a eliminar:    ${totalAEliminar}`);
+  console.log(`  - Recetas a actualizar:  ${totalRecetasAfectadas}`);
+
+  if (!args.apply) {
+    console.log("\n💡 Esto fue DRY-RUN. Para aplicar:");
+    console.log("   node scripts/dedupe-insumos.js --apply");
+    console.log("   (o con --canonical=newest|cheapest si quieres otra estrategia)");
+  } else {
+    console.log("\n✅ Aplicado. Recetas y duplicados procesados.");
+  }
+
+  await mongoose.disconnect();
+}
+
+main().catch(err => {
+  console.error("Error:", err);
+  mongoose.disconnect();
+  process.exit(1);
+});

--- a/src/models/insumos.js
+++ b/src/models/insumos.js
@@ -1,17 +1,19 @@
 const mongoose = require("mongoose");
+const { normalizeName } = require("../utils/normalizeName");
 
 /**
  * Insumo / materia prima.
  *
- * El `name` y `unit` antes tenían un regex `/^[A-Za-z]+$/` que rechazaba
- * cualquier nombre con espacios, acentos, números o porcentajes — eso
- * bloqueaba ingredientes legítimos como "Nuez de Macadamia", "Plátano",
- * "Chocolate 70%" o "Harina 000". El regex está fuera; en su lugar
- * limitamos por longitud y dejamos pasar nombres naturales.
+ * El `name` antes tenía un regex `/^[A-Za-z]+$/` que rechazaba espacios,
+ * acentos, números y porcentajes. Se quitó y se validan por longitud.
  *
- * `amount` y `cost` son Number, así que el `match: [regex]` anterior era
- * código muerto (Mongoose solo evalúa regex en Strings). Se reemplaza
- * por `min: 0` que sí valida.
+ * Para detección de duplicados se mantiene un campo derivado
+ * `nameNormalized` (trim + lowercase + sin acentos + colapsar espacios)
+ * que se recalcula automáticamente cuando cambia `name` mediante hooks
+ * pre('save') y pre('findOneAndUpdate'). El índice NO es `unique` para
+ * no romper si existen duplicados históricos — la validación de
+ * duplicados se hace a nivel de aplicación en las rutas POST/PUT, que
+ * además permiten devolver un mensaje claro con el id del existente.
  */
 const insumosSchema = new mongoose.Schema(
   {
@@ -21,6 +23,10 @@ const insumosSchema = new mongoose.Schema(
       trim: true,
       minlength: [1, "El nombre no puede estar vacío"],
       maxlength: [100, "El nombre es demasiado largo (máx 100 caracteres)"],
+    },
+    nameNormalized: {
+      type: String,
+      index: true,  // no unique — la validación se hace en la ruta
     },
     amount: {
       type: Number,
@@ -44,6 +50,31 @@ const insumosSchema = new mongoose.Schema(
     timestamps: true,
   }
 );
+
+// Mantiene nameNormalized sincronizado con name en todos los flujos
+// de escritura. Cubre tanto Mongoose.save() como findOneAndUpdate().
+insumosSchema.pre("save", function (next) {
+  if (this.isModified("name")) {
+    this.nameNormalized = normalizeName(this.name);
+  }
+  next();
+});
+
+insumosSchema.pre("findOneAndUpdate", function (next) {
+  const update = this.getUpdate() || {};
+  // Soporta tanto { name: "..." } como { $set: { name: "..." } }
+  const newName = update.name ?? update.$set?.name;
+  if (newName !== undefined) {
+    const normalized = normalizeName(newName);
+    if (update.$set) {
+      update.$set.nameNormalized = normalized;
+    } else {
+      update.nameNormalized = normalized;
+    }
+    this.setUpdate(update);
+  }
+  next();
+});
 
 const Insumos = mongoose.model("insumos", insumosSchema);
 

--- a/src/routes/insumos.js
+++ b/src/routes/insumos.js
@@ -3,13 +3,52 @@ const router = express.Router();
 const Insumos = require("../models/insumos");
 const Receta = require("../models/recetas/recetas");
 const checkRoleToken = require("../middlewares/myRoleToken");
+const { normalizeName } = require("../utils/normalizeName");
 
 // Enviar Insumo (POST) — solo admin
+// Antes de crear, valida que no exista otro insumo con nombre equivalente
+// (case/accent-insensitive). Si lo hay, responde 409 Conflict con el
+// insumo existente para que el front pueda ofrecer "usar éste" en vez
+// de pisar al admin con un duplicado silencioso.
 router.post("/", checkRoleToken("admin"), async (req, res) => {
   try {
-    const insumo = req.body;
+    const insumo = req.body || {};
+    if (typeof insumo.name === "string" && insumo.name.trim()) {
+      const normalized = normalizeName(insumo.name);
+      const existente = await Insumos.findOne({ nameNormalized: normalized });
+      if (existente) {
+        return res.status(409).send({
+          message: `Ya existe un insumo con ese nombre: "${existente.name}"`,
+          existente,
+        });
+      }
+    }
     const newInsumo = await Insumos.create(insumo);
     res.status(201).send({ message: "Insumo created", data: newInsumo });
+  } catch (error) {
+    res.status(400).send({ message: error.message });
+  }
+});
+
+// Buscar insumos similares por nombre — útil en autocomplete del form.
+// Normaliza la query y devuelve hasta 5 matches por substring sobre
+// `nameNormalized`. Devuelve siempre 200 (lista vacía si no hay match).
+// No requiere autenticación porque solo lee; si más adelante hay info
+// sensible en insumos, agregar checkRoleToken.
+router.get("/buscar-similares", async (req, res) => {
+  try {
+    const q = String(req.query.q || "").trim();
+    if (!q) return res.status(200).send({ data: [] });
+    const normalized = normalizeName(q);
+    if (!normalized) return res.status(200).send({ data: [] });
+    // Escapar caracteres especiales de regex (ej: paréntesis, +, etc.)
+    const escaped = normalized.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const matches = await Insumos.find({
+      nameNormalized: { $regex: escaped, $options: "i" },
+    })
+      .limit(5)
+      .sort({ nameNormalized: 1 });
+    res.status(200).send({ data: matches });
   } catch (error) {
     res.status(400).send({ message: error.message });
   }
@@ -52,9 +91,21 @@ router.get("/:id", async (req, res) => {
 // Actualizar un Insumo (PUT) — solo admin
 // Tras actualizar, recalcula automáticamente el precio en todas las recetas
 // que referencian este insumo mediante insumoId.
+// Si el body cambia el `name`, antes valida que no choque con otro insumo
+// existente (excluyendo el propio :id). Si choca → 409.
 router.put("/:id", checkRoleToken("admin"), async (req, res) => {
   try {
     const { id } = req.params;
+    if (typeof req.body?.name === "string" && req.body.name.trim()) {
+      const normalized = normalizeName(req.body.name);
+      const choque = await Insumos.findOne({ nameNormalized: normalized, _id: { $ne: id } });
+      if (choque) {
+        return res.status(409).send({
+          message: `Ya existe otro insumo con ese nombre: "${choque.name}"`,
+          existente: choque,
+        });
+      }
+    }
     const updatedInsumo = await Insumos.findByIdAndUpdate(id, req.body, { new: true });
     if (!updatedInsumo) return res.status(404).send({ message: "Insumo not found" });
 

--- a/src/utils/normalizeName.js
+++ b/src/utils/normalizeName.js
@@ -1,0 +1,32 @@
+/**
+ * Normaliza un nombre para comparaciones de duplicados / búsqueda.
+ *
+ * Aplica:
+ *  - trim de espacios al inicio/final
+ *  - lowercase
+ *  - quita acentos / diacríticos (á → a, ñ → n, ü → u, etc.)
+ *  - colapsa múltiples espacios internos a uno solo
+ *
+ * Usado por:
+ *  - models/insumos.js (campo `nameNormalized`, indexado)
+ *  - routes/insumos.js (validación POST/PUT, endpoint /buscar-similares)
+ *  - scripts/dedupe-insumos.js (detección de grupos a fusionar)
+ *
+ * Ejemplos:
+ *  "Harina"             → "harina"
+ *  "  Harina  "         → "harina"
+ *  "Plátano"            → "platano"
+ *  "NUEZ  de macadamia" → "nuez de macadamia"
+ *  "Chocolate 70%"      → "chocolate 70%"
+ */
+function normalizeName(name) {
+  if (typeof name !== "string") return "";
+  return name
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")  // remueve diacríticos
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+module.exports = { normalizeName };


### PR DESCRIPTION
## Summary

**PR back** de la feature (PR front llega aparte). Resuelve el escenario que reportó Alberto:
- Hoy se podían meter "Harina" + "harina" + "Harina " + "Plátano" + "Platano" como insumos distintos.
- Y el caso semántico ("Macadamia" vs "Nuez de Macadamia") pasaba sin aviso.

## Cambios

### 1. Bloqueo automático de duplicados normalizados

**`src/utils/normalizeName.js`** (nuevo) — función pura: trim + lowercase + sin acentos + colapsar espacios. 12/12 casos de smoke test pasan.

**`src/models/insumos.js`** — agregado campo derivado `nameNormalized` (indexado, no unique) + hooks `pre('save')` y `pre('findOneAndUpdate')` que lo mantienen en sync.

**`src/routes/insumos.js`** — POST y PUT verifican antes de escribir. Si encuentran otro insumo con el mismo `nameNormalized` → **409 Conflict** con \`{ message, existente }\`. El front puede usar \`existente\` para ofrecer "usar éste".

### 2. Búsqueda asistida (autocomplete)

**`GET /insumos/buscar-similares?q=...`** (nuevo) — devuelve hasta 5 insumos cuyo \`nameNormalized\` haga match substring con la query normalizada. Útil para el form de agregar: al tipear "Macadamia" sugiere "Nuez de Macadamia".

### 3. Script de migración

**`scripts/dedupe-insumos.js`** (nuevo) — DRY-RUN por default, detecta grupos de duplicados y reporta qué recetas referencian a cuáles. Con \`--apply\` ejecuta la fusión: reescribe \`ingredientes.insumoId\` en las recetas al canónico y borra los duplicados.

Uso:
\`\`\`bash
# Solo reportar
node scripts/dedupe-insumos.js

# Aplicar (canónico = el más antiguo)
node scripts/dedupe-insumos.js --apply

# Otras estrategias
node scripts/dedupe-insumos.js --apply --canonical=newest
node scripts/dedupe-insumos.js --apply --canonical=cheapest
\`\`\`

El script también hace **backfill** de \`nameNormalized\` para insumos viejos que no lo tengan.

⚠️ **Importante**: hacer backup de Mongo Atlas antes de correr con \`--apply\`.

## Smoke tests

- ✅ \`normalizeName\`: 12/12 (\"Plátano\"→\"platano\", \"NUEZ  de macadamia\"→\"nuez de macadamia\", etc.)
- ✅ Modelo: hook pre('save') sincroniza nameNormalized
- ✅ Router: 7 endpoints registrados (incluye \`/buscar-similares\`)
- ✅ \`node --check\` en los 4 archivos

## Test plan en preview

- [ ] Intentar crear \"Harina\" 2 veces → segundo intento devuelve 409 con el primero
- [ ] Crear \"Plátano\" y después intentar \"Platano\" → 409 (mismo normalizado)
- [ ] \`GET /insumos/buscar-similares?q=Macadamia\` → si existe \"Nuez de Macadamia\", la devuelve
- [ ] Editar un insumo cambiando su nombre por uno que ya existe → 409
- [ ] Correr \`node scripts/dedupe-insumos.js\` en staging → reporta grupos (probablemente 0 si la DB está limpia)
- [ ] Insertar duplicados a propósito, correr script con \`--apply\` y verificar que las recetas siguen calculando bien

## Out of scope (PR siguiente)

- Frontend: autocomplete en form de agregar/editar insumo + manejo visual de 409 con CTA "usar el existente".

🤖 Generated with [Claude Code](https://claude.com/claude-code)