### PR TITLE
fix(insumos): detectar duplicados legacy + endpoint /merge

### DIFF
--- a/src/routes/insumos.js
+++ b/src/routes/insumos.js
@@ -5,6 +5,47 @@ const Receta = require("../models/recetas/recetas");
 const checkRoleToken = require("../middlewares/myRoleToken");
 const { normalizeName } = require("../utils/normalizeName");
 
+/**
+ * Busca un insumo existente con nombre normalizado equivalente al dado.
+ *
+ * Maneja entries LEGACY que no tienen el campo `nameNormalized` poblado
+ * (creadas antes de que existiera el hook): si encuentra alguna sin el
+ * campo, normaliza en JS, compara, y de paso aprovecha para reparar
+ * (backfill) en background — así el siguiente POST corre rápido por el
+ * índice.
+ *
+ * @param {string} name        nombre crudo a comparar
+ * @param {string|null} excludeId  id de un insumo a excluir (para PUT)
+ * @returns {Promise<Insumos|null>}
+ */
+async function findDuplicateByName(name, excludeId = null) {
+  const normalized = normalizeName(name);
+  if (!normalized) return null;
+
+  // Path rápido: lookup directo por nameNormalized (índice).
+  let query = { nameNormalized: normalized };
+  if (excludeId) query._id = { $ne: excludeId };
+  const fast = await Insumos.findOne(query);
+  if (fast) return fast;
+
+  // Path lento: entries legacy sin nameNormalized. Para una colección
+  // pequeña (pastelería) el costo es trivial. Normalizamos en JS.
+  query = { $or: [{ nameNormalized: { $exists: false } }, { nameNormalized: null }, { nameNormalized: "" }] };
+  if (excludeId) query._id = { $ne: excludeId };
+  const legacy = await Insumos.find(query);
+  if (!legacy.length) return null;
+
+  // Aprovechamos para reparar el backfill en background (no bloquea
+  // la respuesta al cliente).
+  Promise.all(
+    legacy.map(i =>
+      Insumos.updateOne({ _id: i._id }, { $set: { nameNormalized: normalizeName(i.name) } })
+    )
+  ).catch(e => console.error("[insumos] backfill nameNormalized error:", e.message));
+
+  return legacy.find(i => normalizeName(i.name) === normalized) || null;
+}
+
 // Enviar Insumo (POST) — solo admin
 // Antes de crear, valida que no exista otro insumo con nombre equivalente
 // (case/accent-insensitive). Si lo hay, responde 409 Conflict con el
@@ -14,8 +55,7 @@ router.post("/", checkRoleToken("admin"), async (req, res) => {
   try {
     const insumo = req.body || {};
     if (typeof insumo.name === "string" && insumo.name.trim()) {
-      const normalized = normalizeName(insumo.name);
-      const existente = await Insumos.findOne({ nameNormalized: normalized });
+      const existente = await findDuplicateByName(insumo.name);
       if (existente) {
         return res.status(409).send({
           message: `Ya existe un insumo con ese nombre: "${existente.name}"`,
@@ -97,8 +137,7 @@ router.put("/:id", checkRoleToken("admin"), async (req, res) => {
   try {
     const { id } = req.params;
     if (typeof req.body?.name === "string" && req.body.name.trim()) {
-      const normalized = normalizeName(req.body.name);
-      const choque = await Insumos.findOne({ nameNormalized: normalized, _id: { $ne: id } });
+      const choque = await findDuplicateByName(req.body.name, id);
       if (choque) {
         return res.status(409).send({
           message: `Ya existe otro insumo con ese nombre: "${choque.name}"`,
@@ -133,6 +172,79 @@ router.put("/:id", checkRoleToken("admin"), async (req, res) => {
     });
   } catch (error) {
     res.status(400).send({ message: error.message });
+  }
+});
+
+// POST /insumos/merge — fusionar duplicados manualmente — solo admin.
+// Body: { canonicalId: "...", duplicateIds: ["...", "..."] }
+//
+// Para cada insumo en duplicateIds:
+//   1) Encuentra recetas que referencian `ingredientes.insumoId`.
+//   2) Reescribe la referencia al `canonicalId`.
+//   3) Recalcula `total_cost` de la receta (porque el insumo canónico
+//      puede tener costo/cantidad distintos).
+//   4) Borra el duplicado.
+//
+// El canonicalId no se modifica.
+// Idéntica lógica que el script CLI scripts/dedupe-insumos.js pero
+// expuesta vía API para que el admin la dispare desde el dashboard.
+router.post("/merge", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const { canonicalId, duplicateIds } = req.body || {};
+    if (!canonicalId || !Array.isArray(duplicateIds) || duplicateIds.length === 0) {
+      return res.status(400).send({ message: "Se requiere canonicalId y duplicateIds (array no vacío)" });
+    }
+    // Defensa: nunca eliminar el canonical, aunque venga en la lista.
+    const dupIds = duplicateIds.filter(id => String(id) !== String(canonicalId));
+    if (!dupIds.length) {
+      return res.status(400).send({ message: "duplicateIds no puede incluir solo al canonical" });
+    }
+
+    const canonical = await Insumos.findById(canonicalId);
+    if (!canonical) return res.status(404).send({ message: "Insumo canónico no encontrado" });
+
+    const duplicates = await Insumos.find({ _id: { $in: dupIds } });
+    if (duplicates.length === 0) {
+      return res.status(404).send({ message: "Ninguno de los duplicados existe" });
+    }
+    const validDupIds = duplicates.map(d => d._id);
+
+    // Reescribir referencias en recetas y recalcular total_cost
+    const recetas = await Receta.find({ "ingredientes.insumoId": { $in: validDupIds } });
+    const unitCost = canonical.cost / (canonical.amount || 1);
+
+    for (const receta of recetas) {
+      let touched = false;
+      receta.ingredientes.forEach(ing => {
+        if (ing.insumoId && validDupIds.some(id => String(id) === String(ing.insumoId))) {
+          ing.insumoId = canonical._id;
+          ing.precio = Math.round(unitCost * (ing.cantidad || 0) * 100) / 100;
+          ing.total  = Math.round(unitCost * 100) / 100;
+          touched = true;
+        }
+      });
+      if (touched) {
+        const ingTotal = receta.ingredientes.reduce((s, i) => s + (i.precio || 0), 0);
+        const rawCost  = ingTotal + (receta.additional_costs || 0);
+        receta.total_cost = Math.round((rawCost + rawCost * (receta.special_tax || 0) / 100) * 100) / 100;
+        await receta.save();
+      }
+    }
+
+    // Borrar duplicados
+    await Insumos.deleteMany({ _id: { $in: validDupIds } });
+
+    res.status(200).send({
+      message: "Merge completado",
+      data: {
+        canonical,
+        eliminados: validDupIds.length,
+        recetasActualizadas: recetas.length,
+      },
+    });
+  } catch (error) {
+    console.error("Error en merge de insumos:", error);
+    res.status(500).send({ message: error.message });
   }
 });
 


### PR DESCRIPTION
## Bug reportado

Después de mergear [#63](https://github.com/mipasteleria/BackPastelero/pull/63), el admin pudo crear \"Harina\" 2 veces sin que el back bloqueara el duplicado.

## Causa

Las \"Harina\" preexistentes en BD se crearon **antes** de que existiera el campo \`nameNormalized\` y el hook \`pre('save')\`. Esas entries no lo tienen poblado.

La query \`findOne({ nameNormalized: \"harina\" })\` no las encuentra (Mongo solo matchea docs donde el campo existe). El nuevo \"Harina\" pasa y se duplica.

## Fix 1 — Manejo legacy

Nuevo helper \`findDuplicateByName(name, excludeId)\` que:

1. **Path rápido**: lookup directo por \`nameNormalized\` (con índice).
2. **Path lento**: si no encuentra, busca entries sin \`nameNormalized\`, normaliza en JS y compara.
3. **Auto-backfill**: aprovecha para reparar las entries legacy en background (\`Promise.all\` sin await) — la siguiente petición corre rápido por el índice.

Aplicado a \`POST /\` y \`PUT /:id\`.

## Fix 2 — Endpoint POST /insumos/merge

Para que el admin fusione duplicados desde el dashboard sin correr el script CLI.

**Body**:
\`\`\`json
{ \"canonicalId\": \"...\", \"duplicateIds\": [\"...\", \"...\"] }
\`\`\`

**Hace**:
- Reasigna referencias en \`receta.ingredientes.insumoId\` de duplicados → canonical.
- **Recalcula \`total_cost\`** de las recetas afectadas (porque el canonical puede tener costo/cantidad distintos).
- Borra los duplicados.
- Defensa: nunca borra el canonical aunque venga en \`duplicateIds\`.

**Response**:
\`\`\`json
{
  \"message\": \"Merge completado\",
  \"data\": { \"canonical\": {...}, \"eliminados\": 2, \"recetasActualizadas\": 3 }
}
\`\`\`

## Test plan

- [ ] Intentar crear \"Harina\" cuando ya existen 2 \"Harina\" legacy → debe devolver 409
- [ ] Verificar en MongoDB que las 2 \"Harina\" legacy ahora tienen \`nameNormalized: \"harina\"\` (efecto del backfill)
- [ ] POST a \`/insumos/merge\` con \`{ canonicalId: idA, duplicateIds: [idB] }\` → debe devolver 200 con \`eliminados: 1\`
- [ ] Verificar que las recetas que usaban idB ahora usan idA con total_cost recalculado

## Out of scope

- Frontend: UI con checkboxes para seleccionar duplicados y disparar el merge desde el dashboard. PR aparte.
- Fix CSS de líneas en columna \"Acciones\" del listado. PR aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)