### PR TITLE
feat(cotizaciones): evento en Google Calendar al confirmar pedido

### DIFF
--- a/src/models/cupcakesCotiza.js
+++ b/src/models/cupcakesCotiza.js
@@ -100,6 +100,11 @@ const cupcakesSchema = new mongoose.Schema(
       type: costeoSnapshotSchema,
       default: null,
     },
+    // ID del evento de Google Calendar (mismo patrón que pastelCotiza).
+    calendarEventId: {
+      type: String,
+      default: "",
+    },
   },
   {
     timestamps: true,

--- a/src/models/pastelCotiza.js
+++ b/src/models/pastelCotiza.js
@@ -117,6 +117,14 @@ const pastelSchema = new mongoose.Schema(
       type: costeoSnapshotSchema,
       default: null,
     },
+    // ID del evento creado en Google Calendar cuando la cotización pasa a
+    // estado "Agendado...". Se usa para borrar el evento si después se
+    // cancela. Empty string = sin evento (más friendly que null para
+    // comparaciones en el código).
+    calendarEventId: {
+      type: String,
+      default: "",
+    },
   },
   {
     timestamps: true,

--- a/src/models/snackCotiza.js
+++ b/src/models/snackCotiza.js
@@ -108,6 +108,11 @@ const snacksSchema = new mongoose.Schema(
       type: costeoSnapshotSchema,
       default: null,
     },
+    // ID del evento de Google Calendar (mismo patrón que pastelCotiza).
+    calendarEventId: {
+      type: String,
+      default: "",
+    },
   },
   {
     timestamps: true,

--- a/src/routes/create-payment-intent/webhook.js
+++ b/src/routes/create-payment-intent/webhook.js
@@ -10,7 +10,7 @@ const Snack = require("../../models/snackCotiza");
 const GalletaPedido = require("../../models/galletaPedido");
 const GalletaSabor  = require("../../models/galletaSabor");
 const { sendGalletaConfirmation, sendGalletaConfirmationToAdmin, sendLowStockAlert } = require("./galletaEmails");
-const { createGalletaEvent } = require("../../utils/googleCalendar");
+const { createGalletaEvent, createCotizacionEvent } = require("../../utils/googleCalendar");
 
 /**
  * POST /webhook/stripe
@@ -91,6 +91,22 @@ async function markPaymentFinal(session, finalStatus) {
     cotizacion.saldoPendiente = 0;
   }
   await cotizacion.save();
+
+  // ── Crear evento en Google Calendar (idempotente) ──
+  // Solo si la cotización aún no tiene calendarEventId (evita
+  // duplicados cuando paga primero anticipo y después saldo).
+  // En su propio try/catch para no romper el webhook si Calendar falla.
+  if (!cotizacion.calendarEventId) {
+    try {
+      const eventId = await createCotizacionEvent(cotizacion, payment.cotizacionType);
+      if (eventId) {
+        cotizacion.calendarEventId = eventId;
+        await cotizacion.save();
+      }
+    } catch (e) {
+      console.error(`[webhook] error creando evento Calendar para cotización ${cotizacion._id}:`, e.message);
+    }
+  }
 }
 
 router.post("/", async (req, res) => {

--- a/src/routes/cupcakesCotiza.js
+++ b/src/routes/cupcakesCotiza.js
@@ -4,6 +4,7 @@ const Prices = require("../models/cupcakesCotiza");
 const checkRoleToken = require("../middlewares/myRoleToken");
 const { requireAuth } = checkRoleToken;
 const { calcularCosteo } = require("../jobs/costeoHandler");
+const { syncCotizacionCalendar } = require("../utils/cotizacionCalendarSync");
 
 //Enviar Cotización Cupcake
 router.post("/", async (req, res) => {
@@ -48,6 +49,8 @@ router.put("/:id", checkRoleToken("admin"), async (req, res) => {
     const newPrices = await Prices.findByIdAndUpdate(id, newPrice, {
       returnOriginal: false,
     });
+    // Sincronizar Google Calendar (no bloquea).
+    syncCotizacionCalendar(Prices, newPrices, "Cupcake");
     res.send({ message: "Price updated", data: newPrices });
   } catch (error) {
     res.status(400).send({ message: error });

--- a/src/routes/pastelCotiza.js
+++ b/src/routes/pastelCotiza.js
@@ -4,6 +4,7 @@ const Prices = require("../models/pastelCotiza");
 const checkRoleToken = require("../middlewares/myRoleToken");
 const { requireAuth } = checkRoleToken;
 const { calcularCosteo } = require("../jobs/costeoHandler");
+const { syncCotizacionCalendar } = require("../utils/cotizacionCalendarSync");
 
 //Enviar Cotización Cake
 router.post("/", async (req, res) => {
@@ -56,6 +57,11 @@ router.put("/:id", checkRoleToken("admin"), async (req, res) => {
     if (!updatedPrice) {
       return res.status(404).send({ message: "Price not found" });
     }
+
+    // Sincronizar Google Calendar (no bloquea la respuesta).
+    // Si status pasó a "Agendado..." sin calendarEventId → crea evento.
+    // Si status pasó a "Cancelado" y hay calendarEventId → borra evento.
+    syncCotizacionCalendar(Prices, updatedPrice, "Pastel");
 
     res.send({ message: "Price updated", data: updatedPrice });
   } catch (error) {

--- a/src/routes/snackCotiza.js
+++ b/src/routes/snackCotiza.js
@@ -4,6 +4,7 @@ const Prices = require("../models/snackCotiza");
 const checkRoleToken = require("../middlewares/myRoleToken");
 const { requireAuth } = checkRoleToken;
 const { calcularCosteo } = require("../jobs/costeoHandler");
+const { syncCotizacionCalendar } = require("../utils/cotizacionCalendarSync");
 
 //Enviar Cotización Snack
 router.post("/", async (req, res) => {
@@ -47,6 +48,8 @@ router.put("/:id", checkRoleToken("admin"), async (req, res) => {
     const newPrices = await Prices.findByIdAndUpdate(id, newPrice, {
       returnOriginal: false,
     });
+    // Sincronizar Google Calendar (no bloquea).
+    syncCotizacionCalendar(Prices, newPrices, "Snack");
     res.send({ message: "Price updated", data: newPrices });
   } catch (error) {
     res.status(400).send({ message: error });

--- a/src/utils/cotizacionCalendarSync.js
+++ b/src/utils/cotizacionCalendarSync.js
@@ -1,0 +1,49 @@
+const { createCotizacionEvent, deleteEvent } = require("./googleCalendar");
+
+/**
+ * Sincroniza Google Calendar con el estado actual de una cotización.
+ *
+ * Llamar después de un `findByIdAndUpdate` u otra mutación que toque
+ * `status` o `calendarEventId`. No bloquea (corre en background).
+ *
+ * Reglas:
+ *   - Si status empieza con "Agendado" y no hay calendarEventId todavía
+ *     → crea evento y guarda el id.
+ *   - Si status === "Cancelado" y hay calendarEventId → borra el evento
+ *     y limpia el id.
+ *   - Cualquier otra transición no toca Calendar (idempotencia).
+ *
+ * @param {mongoose.Model} Model    El modelo (Pastel/Cupcake/Snack Cotiza)
+ * @param {object} cotizacion       El documento ya actualizado
+ * @param {string} tipo             "Pastel" | "Cupcake" | "Snack"
+ */
+function syncCotizacionCalendar(Model, cotizacion, tipo) {
+  if (!cotizacion) return;
+  const status = cotizacion.status || "";
+  const isAgendado = status.startsWith("Agendado");
+  const isCancelado = status === "Cancelado";
+
+  if (isAgendado && !cotizacion.calendarEventId) {
+    // Transición a Agendado sin evento todavía → crearlo
+    createCotizacionEvent(cotizacion, tipo)
+      .then(async (eventId) => {
+        if (eventId) {
+          await Model.findByIdAndUpdate(cotizacion._id, { $set: { calendarEventId: eventId } });
+        }
+      })
+      .catch(e => console.error(`[gcal] error sync create ${tipo} ${cotizacion._id}:`, e.message));
+    return;
+  }
+
+  if (isCancelado && cotizacion.calendarEventId) {
+    // Cancelación → borrar evento y limpiar el id
+    const eventIdAnterior = cotizacion.calendarEventId;
+    deleteEvent(eventIdAnterior)
+      .then(async () => {
+        await Model.findByIdAndUpdate(cotizacion._id, { $set: { calendarEventId: "" } });
+      })
+      .catch(e => console.error(`[gcal] error sync delete ${tipo} ${cotizacion._id}:`, e.message));
+  }
+}
+
+module.exports = { syncCotizacionCalendar };

--- a/src/utils/googleCalendar.js
+++ b/src/utils/googleCalendar.js
@@ -201,6 +201,154 @@ async function createGalletaEvent(pedido) {
 }
 
 /**
+ * Parsea el `deliveryDate` que viene de cotizaciones (pastel/cupcake/snack)
+ * con formato "DD/MM/YYYY HH:MM" → { fechaISO: "YYYY-MM-DD", hora: "HH:MM" }.
+ *
+ * Si el string viene en otro formato (ej. solo fecha sin hora) intentamos
+ * un fallback razonable; si nada matchea retorna null para que la lógica
+ * superior decida no crear el evento.
+ */
+function parseDeliveryDateStr(s) {
+  if (typeof s !== "string" || !s.trim()) return null;
+  // Match "DD/MM/YYYY HH:MM" o "DD/MM/YYYY HH:MM:SS"
+  let m = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})\s+(\d{1,2}):(\d{2})/);
+  if (m) {
+    const [, dd, mm, yyyy, hh, min] = m;
+    return {
+      fechaISO: `${yyyy}-${mm.padStart(2, "0")}-${dd.padStart(2, "0")}`,
+      hora: `${hh.padStart(2, "0")}:${min}`,
+    };
+  }
+  // Fallback: solo fecha "DD/MM/YYYY" → asumimos 12:00
+  m = s.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+  if (m) {
+    const [, dd, mm, yyyy] = m;
+    return {
+      fechaISO: `${yyyy}-${mm.padStart(2, "0")}-${dd.padStart(2, "0")}`,
+      hora: "12:00",
+    };
+  }
+  // Fallback: "YYYY-MM-DD HH:MM"
+  m = s.match(/^(\d{4})-(\d{2})-(\d{2})\s+(\d{1,2}):(\d{2})/);
+  if (m) {
+    const [, yyyy, mm, dd, hh, min] = m;
+    return {
+      fechaISO: `${yyyy}-${mm}-${dd}`,
+      hora: `${hh.padStart(2, "0")}:${min}`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Crea un evento en Google Calendar para una cotización (pastel/cupcake/snack).
+ *
+ * @param {object} cotizacion  El documento de cotización con todos sus campos
+ * @param {string} tipo        "Pastel" | "Cupcake" | "Snack"
+ *
+ * Retorna el ID del evento creado, o null si Calendar no está configurado
+ * o si la cotización no tiene `deliveryDate` parseable.
+ */
+async function createCotizacionEvent(cotizacion, tipo) {
+  const calendar = getCalendarClient();
+  if (!calendar) return null;
+
+  // Sin deliveryDate parseable no podemos agendar. No falla, solo
+  // logueamos y devolvemos null.
+  const parsed = parseDeliveryDateStr(cotizacion.deliveryDate);
+  if (!parsed) {
+    console.warn(`[gcal] cotización ${cotizacion._id} sin deliveryDate válido — no se crea evento`);
+    return null;
+  }
+
+  try {
+    const emoji = tipo === "Pastel" ? "🎂" : tipo === "Cupcake" ? "🧁" : "🍫";
+    const tipoLower = (tipo || "Pedido").toLowerCase();
+    const cantidad = cotizacion.portions ? `${cotizacion.portions} porc` : null;
+    const flavor = cotizacion.flavor || "";
+
+    // Title: "🎂 Pastel · 30 porc · Vainilla · {contactName}"
+    const summary = [
+      `${emoji} ${tipo || "Pedido"}`,
+      cantidad,
+      flavor,
+      cotizacion.contactName,
+    ].filter(Boolean).join(" · ");
+
+    const esEnvio = !!(cotizacion.deliveryAdress && String(cotizacion.deliveryAdress).trim());
+
+    const detalles = [
+      `Tipo: ${tipo || "—"}`,
+      flavor ? `Sabor: ${flavor}` : null,
+      cotizacion.stuffedFlavor ? `Relleno: ${cotizacion.stuffedFlavor}` : null,
+      cotizacion.cover ? `Cobertura: ${cotizacion.cover}` : null,
+      cotizacion.levels ? `Pisos: ${cotizacion.levels}` : null,
+      cotizacion.portions ? `Porciones: ${cotizacion.portions}` : null,
+    ].filter(Boolean).join("\n");
+
+    const description = [
+      `Cliente: ${cotizacion.contactName || "—"}`,
+      `Teléfono: ${cotizacion.contactPhone || "—"}`,
+      ``,
+      esEnvio ? `🚗 Envío a domicilio` : `🏪 Recogida en sucursal`,
+      ``,
+      detalles,
+      ``,
+      cotizacion.precio != null ? `Precio total: $${cotizacion.precio}` : null,
+      cotizacion.anticipo != null ? `Anticipo: $${cotizacion.anticipo}` : null,
+      cotizacion.saldoPendiente != null ? `Saldo pendiente: $${cotizacion.saldoPendiente}` : null,
+      cotizacion.status ? `Estado: ${cotizacion.status}` : null,
+      ``,
+      cotizacion.questionsOrComments ? `Notas del cliente: ${cotizacion.questionsOrComments}` : null,
+    ].filter(Boolean).join("\n");
+
+    let location = "Calle Bogotá 2866a, Col. Providencia, Guadalajara, Jal.";
+    if (esEnvio) location = cotizacion.deliveryAdress;
+
+    // Tiempo: 60 min de duración por defecto (los pasteles suelen requerir
+    // más coordinación que las galletas).
+    const startISO = combinarFechaHora(parsed.fechaISO, parsed.hora);
+    const endISO   = sumarMinutos(startISO, 60);
+
+    const event = {
+      summary,
+      description,
+      location,
+      start: { dateTime: startISO, timeZone: TIMEZONE },
+      end:   { dateTime: endISO,   timeZone: TIMEZONE },
+      // Color distinto del de Galletas NY (4=Flamingo, 11=Rojo) para
+      // distinguir visualmente. 9 = Blueberry (azul) para cotizaciones
+      // de recogida; 6 = Tangerine (naranja) para envíos.
+      colorId: esEnvio ? "6" : "9",
+      reminders: {
+        useDefault: false,
+        overrides: [
+          { method: "popup", minutes: 24 * 60 },
+          { method: "popup", minutes: 60 },
+        ],
+      },
+      extendedProperties: {
+        private: {
+          cotizacionId: String(cotizacion._id),
+          tipoProducto: tipoLower,
+        },
+      },
+    };
+
+    const res = await calendar.events.insert({
+      calendarId: getCalendarId(),
+      requestBody: event,
+    });
+
+    console.log(`[gcal] evento de cotización creado (${tipo} ${cotizacion._id}): ${res.data.id}`);
+    return res.data.id;
+  } catch (e) {
+    console.error(`[gcal] error creando evento de cotización ${cotizacion._id}:`, e.message);
+    return null;
+  }
+}
+
+/**
  * Elimina un evento por su ID. Útil al cancelar un pedido.
  * No falla si el evento ya no existe.
  */
@@ -226,5 +374,7 @@ async function deleteEvent(eventId) {
 module.exports = {
   getCalendarClient,
   createGalletaEvent,
+  createCotizacionEvent,
+  parseDeliveryDateStr,
   deleteEvent,
 };


### PR DESCRIPTION
## Summary

Cuando una cotización de Pastel/Cupcake/Snack pasa a estado **\"Agendado…\"** (primer pago vía Stripe, o cambio manual del admin), el sistema crea automáticamente un evento en Google Calendar usando `deliveryDate` (formato \"DD/MM/YYYY HH:MM\" del front).

**Galletas NY ya tenía esta integración** — replicamos el mismo patrón para las cotizaciones tradicionales.

## Reglas

| Transición | Acción |
|---|---|
| status pasa a \"Agendado…\" Y `calendarEventId` está vacío | Crea evento, guarda el id |
| status pasa a \"Cancelado\" Y `calendarEventId` existe | Borra evento, limpia el id |
| Cualquier otra transición | No-op |

**Idempotencia:** si el webhook de Stripe ya creó el evento al pagar el anticipo, un PUT del admin que vuelva a marcar \"Agendado con el 100%\" no duplica el evento.

## Cambios

| Archivo | Cambio |
|---|---|
| `models/pastelCotiza.js` `cupcakesCotiza.js` `snackCotiza.js` | +1 campo opcional `calendarEventId: String, default: \"\"` |
| `utils/googleCalendar.js` | +`parseDeliveryDateStr` +`createCotizacionEvent(cotizacion, tipo)` |
| `utils/cotizacionCalendarSync.js` (nuevo) | Helper `syncCotizacionCalendar` con lógica de transición. Background, errores logueados. |
| `routes/create-payment-intent/webhook.js` | `markPaymentFinal`: crea evento tras guardar el status (try/catch propio) |
| `routes/pastelCotiza.js` `cupcakesCotiza.js` `snackCotiza.js` PUT | Llaman a `syncCotizacionCalendar` tras `findByIdAndUpdate` |

## Detalles del evento

- **Título:** \"🎂 Pastel · 30 porc · Vainilla · Juan Pérez\" (con emoji por tipo)
- **Descripción:** cliente, teléfono, tipo de entrega, sabor, relleno, cobertura, pisos, porciones, precio, anticipo, saldo pendiente, status, notas del cliente.
- **Ubicación:** dirección del cliente si es envío; dirección de la sucursal si es recogida.
- **Color:** Tangerine (envíos) o Blueberry (recogida) — distinto de Galletas NY para distinguir visualmente.
- **Duración:** 60 min (pasteles requieren más coordinación que galletas).
- **Recordatorios:** 24h y 1h antes.

## Compatibilidad

- Si `GOOGLE_CALENDAR_CREDENTIALS` no está configurado → todas las funciones operan en no-op con warning. Mismo patrón que galletas.
- Si `deliveryDate` no es parseable → no se crea evento, se loguea, el flujo sigue normal.
- Cotizaciones existentes sin `calendarEventId` → el campo arranca en \"\" (default del schema). Sin migración requerida.
- El primer admin que cambie manualmente el status de una cotización legacy a \"Agendado\" disparará la creación del evento.

## Smoke tests locales

- `parseDeliveryDateStr`: 7 casos (\"15/06/2026 14:30\", solo fecha, ISO, vacío, null, no-date) ✓
- `syncCotizacionCalendar`: 4 transiciones (crear, borrar, no-op pendiente, no-op idempotente) ✓
- `node --check` en los 9 archivos modificados ✓

## Test plan en preview

- [ ] Crear una cotización de pastel, marcarla manualmente a \"Agendado con el 50%\" → evento aparece en Calendar con fecha/hora correctas
- [ ] Editar la cotización a \"Agendado con el 100%\" → no se duplica el evento
- [ ] Cambiar manualmente a \"Cancelado\" → evento desaparece del Calendar
- [ ] Flujo Stripe completo (cotización → pagar anticipo) → evento creado por el webhook
- [ ] Cotización con `deliveryAdress` vacío → evento usa la dirección de la sucursal
- [ ] Cotización con `deliveryAdress` lleno → evento usa esa dirección

🤖 Generated with [Claude Code](https://claude.com/claude-code)