### PR TITLE
feat(admin): endpoint diagnóstico GET /admin/calendar-status

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ const tecnicasCreativasRoutes = require("./src/routes/tecnicasCreativas.js");
 const productosRoutes = require("./src/routes/productos.js");
 const galletaSaboresRoutes = require("./src/routes/galletaSabores.js");
 const galletaPedidosRoutes = require("./src/routes/galletaPedidos.js");
+const calendarStatusRoutes = require("./src/routes/calendarStatus.js");
 const createCheckoutSession = require("./src/routes/create-payment-intent/server.js");
 const stripeWebhook = require("./src/routes/create-payment-intent/webhook.js");
 const sendConfirmationEmail = require("./src/routes/create-payment-intent/confirmationEmail.js");
@@ -91,6 +92,7 @@ app.use("/galletaSabores", galletaSaboresRoutes);
 app.use("/galletaPedidos", galletaPedidosRoutes);
 app.use("/send-confirmation-email", sendConfirmationEmail);
 app.use("/notificaciones", notificacionesRoutes);
+app.use("/admin", calendarStatusRoutes);
 app.get("/health", (req, res) => {
   res.json({ status: "ok", ts: Date.now() });
 });

--- a/src/routes/calendarStatus.js
+++ b/src/routes/calendarStatus.js
@@ -1,0 +1,149 @@
+const express = require("express");
+const router = express.Router();
+const { google } = require("googleapis");
+const checkRoleToken = require("../middlewares/myRoleToken");
+
+/**
+ * Endpoints de diagnóstico para Google Calendar.
+ *
+ * Útil cuando el admin configura GOOGLE_CALENDAR_CREDENTIALS y
+ * GOOGLE_CALENDAR_ID por primera vez y los eventos no aparecen — este
+ * endpoint ejecuta cada paso de la cadena (env vars → parse → auth →
+ * listar eventos → crear evento de prueba → borrar evento de prueba)
+ * y reporta exactamente dónde falla, sin que tengas que mirar logs.
+ *
+ * Devuelve siempre 200 con un JSON estructurado para que sea fácil de
+ * leer en el navegador (con la extensión JSON viewer o cualquier
+ * cliente REST).
+ */
+
+const TIMEZONE = "America/Mexico_City";
+
+function step(name, ok, detail) {
+  return { step: name, ok, ...detail };
+}
+
+router.get("/calendar-status", checkRoleToken("admin"), async (req, res) => {
+  const results = [];
+  let credentials = null;
+  let calendar = null;
+
+  // 1) Env var GOOGLE_CALENDAR_CREDENTIALS presente
+  const raw = process.env.GOOGLE_CALENDAR_CREDENTIALS;
+  if (!raw) {
+    results.push(step("env_credentials", false, {
+      hint: "Falta GOOGLE_CALENDAR_CREDENTIALS en Vercel. Settings → Environment Variables → Production",
+    }));
+    return res.json({ ok: false, results });
+  }
+  results.push(step("env_credentials", true, { length: raw.length }));
+
+  // 2) Parse JSON
+  try {
+    credentials = JSON.parse(raw);
+  } catch (e) {
+    results.push(step("parse_json", false, {
+      error: e.message,
+      hint: "La env var no es JSON válido. Probablemente quedó truncado o con caracteres extra. Pega el contenido COMPLETO del archivo .json descargado de GCP",
+    }));
+    return res.json({ ok: false, results });
+  }
+  results.push(step("parse_json", true, {
+    client_email: credentials.client_email,
+    project_id: credentials.project_id,
+    has_private_key: !!credentials.private_key,
+  }));
+
+  // 3) Env var GOOGLE_CALENDAR_ID presente
+  const calendarId = process.env.GOOGLE_CALENDAR_ID;
+  if (!calendarId) {
+    results.push(step("env_calendar_id", false, {
+      hint: "Falta GOOGLE_CALENDAR_ID en Vercel. Sácalo de Calendar → Settings del calendario → Integrate calendar → Calendar ID",
+    }));
+    return res.json({ ok: false, results });
+  }
+  results.push(step("env_calendar_id", true, { calendarId }));
+
+  // 4) Autenticación
+  try {
+    const auth = new google.auth.GoogleAuth({
+      credentials,
+      scopes: ["https://www.googleapis.com/auth/calendar.events"],
+    });
+    calendar = google.calendar({ version: "v3", auth });
+    // Forzar generación del token para validar credenciales
+    const authClient = await auth.getClient();
+    await authClient.authorize();
+  } catch (e) {
+    results.push(step("auth", false, {
+      error: e.message,
+      hint: "Las credenciales del service account no son válidas o la Calendar API no está habilitada en el proyecto GCP",
+    }));
+    return res.json({ ok: false, results });
+  }
+  results.push(step("auth", true));
+
+  // 5) Listar eventos (verifica acceso de lectura al calendar)
+  try {
+    const list = await calendar.events.list({
+      calendarId,
+      maxResults: 1,
+    });
+    results.push(step("read_calendar", true, {
+      calendarSummary: list.data.summary || "(sin nombre)",
+      eventos_visibles: list.data.items?.length || 0,
+    }));
+  } catch (e) {
+    let hint = e.message;
+    if (e.code === 404 || /Not Found/i.test(e.message)) {
+      hint = `Calendar ID inválido o el service account (${credentials.client_email}) NO tiene acceso al calendario. Compártelo: Calendar → Settings → Share with specific people → agrega ${credentials.client_email} con permiso "Make changes to events"`;
+    } else if (e.code === 403 || /Forbidden|insufficient/i.test(e.message)) {
+      hint = `El service account no tiene permiso. Asegúrate de compartir el calendario con ${credentials.client_email} y darle "Make changes to events" (no solo "See all event details")`;
+    }
+    results.push(step("read_calendar", false, { error: e.message, code: e.code, hint }));
+    return res.json({ ok: false, results });
+  }
+
+  // 6) Crear evento de prueba (verifica permiso de escritura)
+  let testEventId = null;
+  try {
+    const now = new Date();
+    const start = new Date(now.getTime() + 30 * 60 * 1000); // +30 min
+    const end   = new Date(start.getTime() + 15 * 60 * 1000); // 15 min de duración
+    const evt = await calendar.events.insert({
+      calendarId,
+      requestBody: {
+        summary: "🧪 Test de diagnóstico — borra este evento",
+        description: `Creado por GET /admin/calendar-status a las ${now.toISOString()}. Si lees esto, el integration funciona. Se eliminará automáticamente.`,
+        start: { dateTime: start.toISOString(), timeZone: TIMEZONE },
+        end:   { dateTime: end.toISOString(),   timeZone: TIMEZONE },
+      },
+    });
+    testEventId = evt.data.id;
+    results.push(step("write_calendar", true, { testEventId, htmlLink: evt.data.htmlLink }));
+  } catch (e) {
+    let hint = e.message;
+    if (e.code === 403 || /Forbidden|insufficient/i.test(e.message)) {
+      hint = `El service account puede leer pero no escribir. En el calendar, sube el permiso a "Make changes to events" (no "See all event details")`;
+    }
+    results.push(step("write_calendar", false, { error: e.message, code: e.code, hint }));
+    return res.json({ ok: false, results });
+  }
+
+  // 7) Limpiar el evento de prueba
+  if (testEventId) {
+    try {
+      await calendar.events.delete({ calendarId, eventId: testEventId });
+      results.push(step("cleanup", true));
+    } catch (e) {
+      results.push(step("cleanup", false, {
+        error: e.message,
+        hint: "El evento se creó pero no se pudo borrar. Bórralo manualmente desde Calendar — no es bloqueante",
+      }));
+    }
+  }
+
+  res.json({ ok: true, results, summary: "Calendar configurado correctamente. Los próximos pedidos crearán eventos." });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary

Endpoint admin-only que verifica TODA la cadena de Google Calendar paso a paso y reporta exactamente dónde falla, sin necesidad de mirar logs.

## Uso

Después de mergear y que Vercel redeploye, abre con tu sesión admin:

\`\`\`
GET https://[back-pastelero-prod-url]/admin/calendar-status
\`\`\`

Con el token JWT en el header \`Authorization: Bearer <token>\`. La forma más fácil es desde el front estando logueado como admin — abre DevTools → Console → pega:

\`\`\`js
fetch(`\${process.env.NEXT_PUBLIC_API_BASE_URL || \"https://...\"}/admin/calendar-status`, {
  headers: { Authorization: `Bearer \${localStorage.getItem(\"token\")}` }
}).then(r => r.json()).then(console.log)
\`\`\`

## Pasos verificados

| # | Step | Verifica |
|---|---|---|
| 1 | env_credentials | `GOOGLE_CALENDAR_CREDENTIALS` presente |
| 2 | parse_json | JSON válido, extrae client_email |
| 3 | env_calendar_id | `GOOGLE_CALENDAR_ID` presente |
| 4 | auth | Service account autentica + API habilitada |
| 5 | read_calendar | Sharing del calendar funcionando (lee eventos) |
| 6 | write_calendar | Crea evento de prueba (\"🧪 Test de diagnóstico\") |
| 7 | cleanup | Borra el evento de prueba |

Cada fallo incluye **`hint`** con instrucciones concretas (\"comparte el calendar con foo@bar.iam.gserviceaccount.com con permiso Make changes to events\", etc).

## Ejemplo de response (todo OK)

\`\`\`json
{
  \"ok\": true,
  \"results\": [
    { \"step\": \"env_credentials\", \"ok\": true, \"length\": 2348 },
    { \"step\": \"parse_json\", \"ok\": true, \"client_email\": \"pasteleria-calendar@xxx.iam.gserviceaccount.com\", \"project_id\": \"pasteleria\", \"has_private_key\": true },
    { \"step\": \"env_calendar_id\", \"ok\": true, \"calendarId\": \"xxx@group.calendar.google.com\" },
    { \"step\": \"auth\", \"ok\": true },
    { \"step\": \"read_calendar\", \"ok\": true, \"calendarSummary\": \"Pastelería · Pedidos\", \"eventos_visibles\": 1 },
    { \"step\": \"write_calendar\", \"ok\": true, \"testEventId\": \"...\", \"htmlLink\": \"https://calendar.google.com/event?eid=...\" },
    { \"step\": \"cleanup\", \"ok\": true }
  ],
  \"summary\": \"Calendar configurado correctamente. Los próximos pedidos crearán eventos.\"
}
\`\`\`

## Ejemplo de response (falla típica)

\`\`\`json
{
  \"ok\": false,
  \"results\": [
    { \"step\": \"env_credentials\", \"ok\": true, ... },
    { \"step\": \"parse_json\", \"ok\": true, ... },
    { \"step\": \"env_calendar_id\", \"ok\": true, ... },
    { \"step\": \"auth\", \"ok\": true },
    {
      \"step\": \"read_calendar\",
      \"ok\": false,
      \"error\": \"Not Found\",
      \"code\": 404,
      \"hint\": \"Calendar ID inválido o el service account (xxx@xxx.iam.gserviceaccount.com) NO tiene acceso al calendario. Compártelo: Calendar → Settings → Share with specific people → agrega xxx@xxx.iam.gserviceaccount.com con permiso 'Make changes to events'\"
    }
  ]
}
\`\`\`

## Test plan

- [ ] Llamar al endpoint con sesión admin → devuelve JSON con cada paso
- [ ] Llamar sin auth → 401/403 esperado
- [ ] Llamar siendo usuario normal (no admin) → 403 esperado

🤖 Generated with [Claude Code](https://claude.com/claude-code)