### PR TITLE
feat(pedidos): notas internas de admin con historial + autor

### DIFF
--- a/src/models/cupcakesCotiza.js
+++ b/src/models/cupcakesCotiza.js
@@ -105,6 +105,10 @@ const cupcakesSchema = new mongoose.Schema(
       type: String,
       default: "",
     },
+    notasInternas: {
+      type: [require("./notaInternaSchema")],
+      default: [],
+    },
   },
   {
     timestamps: true,

--- a/src/models/galletaPedido.js
+++ b/src/models/galletaPedido.js
@@ -106,6 +106,14 @@ const galletaPedidoSchema = new mongoose.Schema(
 
     // Google Calendar
     calendarEventId: { type: String, default: "" },
+
+    // Notas internas de admin (append-only desde UI). Ver
+    // src/models/notaInternaSchema.js. Solo se exponen en respuestas
+    // del admin — el endpoint público GET /orden/:numeroOrden las omite.
+    notasInternas: {
+      type: [require("./notaInternaSchema")],
+      default: [],
+    },
   },
   { timestamps: true }
 );

--- a/src/models/notaInternaSchema.js
+++ b/src/models/notaInternaSchema.js
@@ -1,0 +1,40 @@
+const mongoose = require("mongoose");
+
+/**
+ * Subdocumento embebido para notas internas de admin.
+ *
+ * Se usa como elemento de un array `notasInternas` en los modelos
+ * que las soportan (galletaPedido + cotizaciones de pastel/cupcake/snack).
+ *
+ * Características:
+ *   - Append-only desde la UI: el admin agrega notas, no las edita
+ *     (los typos se corrigen con una nota nueva).
+ *   - Sí se puede borrar via DELETE explícito.
+ *   - `fecha` la setea Mongoose automáticamente al insertar
+ *     (usamos timestamps con createdAt renombrado).
+ *   - El autor se captura del `req.user` que mete el middleware de
+ *     auth — `_id` para la traza, `name`/`email` para mostrar.
+ *
+ * NUNCA exponer al cliente final (solo el admin) — estas notas pueden
+ * contener info sensible (método de pago, contacto alterno, etc).
+ */
+const notaInternaSchema = new mongoose.Schema(
+  {
+    texto: {
+      type: String,
+      required: [true, "El texto de la nota es obligatorio"],
+      trim: true,
+      maxlength: [1000, "La nota es demasiado larga (máx 1000 caracteres)"],
+    },
+    autorId:     { type: String, default: "" },
+    autorNombre: { type: String, default: "" },
+    autorEmail:  { type: String, default: "" },
+  },
+  {
+    // createdAt se renombra a "fecha" — más natural en el contexto de notas.
+    // No queremos updatedAt porque las notas son inmutables.
+    timestamps: { createdAt: "fecha", updatedAt: false },
+  }
+);
+
+module.exports = notaInternaSchema;

--- a/src/models/pastelCotiza.js
+++ b/src/models/pastelCotiza.js
@@ -1,5 +1,6 @@
 const mongoose = require("mongoose");
 const costeoSnapshotSchema = require("./costeoSnapshot");
+const notaInternaSchema = require("./notaInternaSchema");
 
 const pastelSchema = new mongoose.Schema(
   {
@@ -124,6 +125,12 @@ const pastelSchema = new mongoose.Schema(
     calendarEventId: {
       type: String,
       default: "",
+    },
+    // Notas internas de admin (append-only desde UI). Ver
+    // src/models/notaInternaSchema.js. NO se expone al cliente final.
+    notasInternas: {
+      type: [notaInternaSchema],
+      default: [],
     },
   },
   {

--- a/src/models/snackCotiza.js
+++ b/src/models/snackCotiza.js
@@ -113,6 +113,10 @@ const snacksSchema = new mongoose.Schema(
       type: String,
       default: "",
     },
+    notasInternas: {
+      type: [require("./notaInternaSchema")],
+      default: [],
+    },
   },
   {
     timestamps: true,

--- a/src/routes/cupcakesCotiza.js
+++ b/src/routes/cupcakesCotiza.js
@@ -5,6 +5,10 @@ const checkRoleToken = require("../middlewares/myRoleToken");
 const { requireAuth } = checkRoleToken;
 const { calcularCosteo } = require("../jobs/costeoHandler");
 const { syncCotizacionCalendar } = require("../utils/cotizacionCalendarSync");
+const { mountNotaInternaRoutes } = require("../utils/notaInternaRoute");
+
+// Notas internas de admin (POST + DELETE en /:id/notas-internas/*).
+mountNotaInternaRoutes(router, Prices, "Cotización Cupcake");
 
 //Enviar Cotización Cupcake
 router.post("/", async (req, res) => {
@@ -19,22 +23,24 @@ router.post("/", async (req, res) => {
   }
 });
 
-//Recuperar Datos Cotización Cupcake — admin ve todo, user solo sus propias
+//Recuperar Datos Cotización Cupcake — admin ve todo, user solo sus propias.
+// `notasInternas` se excluye para non-admin.
 router.get("/", requireAuth, async (req, res) => {
   try {
     const filter = req.user.role === "admin" ? {} : { userId: String(req.user._id) };
-    const pricesData = await Prices.find(filter);
+    const projection = req.user.role === "admin" ? "" : "-notasInternas";
+    const pricesData = await Prices.find(filter).select(projection);
     res.send({ message: "All Prices cupcake", data: pricesData, total: pricesData.length });
   } catch (error) {
     res.status(400).send({ message: error });
   }
 });
 
-//Obtener Cotizaciones por ID Cupcake
+//Obtener Cotizaciones por ID Cupcake — endpoint público, esconde notas internas.
 router.get("/:id", async (req, res) => {
   try {
     const { id } = req.params;
-    const pricesid = await Prices.findById({ _id: id });
+    const pricesid = await Prices.findById({ _id: id }).select("-notasInternas");
     res.send({ message: "Price by ID cupcake", data: pricesid });
   } catch (error) {
     res.status(400).send({ message: error });

--- a/src/routes/galletaPedidos.js
+++ b/src/routes/galletaPedidos.js
@@ -10,8 +10,14 @@ const { generarNumeroOrden } = require("../utils/orderNumber");
 const { resolverZona, ZONAS } = require("../utils/zonasEnvio");
 const { validarFechaHora, getSlotsValidos } = require("../utils/galletaSlots");
 const { createGalletaEvent, deleteEvent } = require("../utils/googleCalendar");
+const { mountNotaInternaRoutes } = require("../utils/notaInternaRoute");
 
 const FRONT_DOMAIN = process.env.FRONT_DOMAIN;
+
+// Notas internas de admin (POST + DELETE en /:id/notas-internas/*).
+// El front-end del cliente NUNCA debe leer este campo. El GET público
+// /orden/:numeroOrden filtra el campo antes de responder.
+mountNotaInternaRoutes(router, GalletaPedido, "Pedido");
 
 /**
  * Rutas de Pedidos de Galletas NY.

--- a/src/routes/pastelCotiza.js
+++ b/src/routes/pastelCotiza.js
@@ -5,6 +5,11 @@ const checkRoleToken = require("../middlewares/myRoleToken");
 const { requireAuth } = checkRoleToken;
 const { calcularCosteo } = require("../jobs/costeoHandler");
 const { syncCotizacionCalendar } = require("../utils/cotizacionCalendarSync");
+const { mountNotaInternaRoutes } = require("../utils/notaInternaRoute");
+
+// Notas internas de admin (POST + DELETE en /:id/notas-internas/*).
+// El front-end del cliente NUNCA debe leer este campo.
+mountNotaInternaRoutes(router, Prices, "Cotización Pastel");
 
 //Enviar Cotización Cake
 router.post("/", async (req, res) => {
@@ -19,22 +24,26 @@ router.post("/", async (req, res) => {
   }
 });
 
-//Recuperar Datos Cotización Cake — admin ve todo, user solo sus propias
+//Recuperar Datos Cotización Cake — admin ve todo, user solo sus propias.
+// `notasInternas` se excluye para non-admin (son info privada del admin).
 router.get("/", requireAuth, async (req, res) => {
   try {
     const filter = req.user.role === "admin" ? {} : { userId: String(req.user._id) };
-    const pricesData = await Prices.find(filter);
+    const projection = req.user.role === "admin" ? "" : "-notasInternas";
+    const pricesData = await Prices.find(filter).select(projection);
     res.send({ message: "All Prices Cake", data: pricesData, total: pricesData.length });
   } catch (error) {
     res.status(400).send({ message: error });
   }
 });
 
-//Obtener Cotizaciones por ID Cake
+//Obtener Cotizaciones por ID Cake — endpoint público.
+// SIEMPRE excluye notasInternas (info admin-only). Si más adelante se
+// agrega auth aquí, considerar devolverlas cuando role === "admin".
 router.get("/:id", async (req, res) => {
   try {
     const { id } = req.params;
-    const pricesid = await Prices.findById({ _id: id });
+    const pricesid = await Prices.findById({ _id: id }).select("-notasInternas");
     res.send({ message: "Price Cake by ID", data: pricesid });
   } catch (error) {
     res.status(400).send({ message: error });

--- a/src/routes/snackCotiza.js
+++ b/src/routes/snackCotiza.js
@@ -5,6 +5,10 @@ const checkRoleToken = require("../middlewares/myRoleToken");
 const { requireAuth } = checkRoleToken;
 const { calcularCosteo } = require("../jobs/costeoHandler");
 const { syncCotizacionCalendar } = require("../utils/cotizacionCalendarSync");
+const { mountNotaInternaRoutes } = require("../utils/notaInternaRoute");
+
+// Notas internas de admin (POST + DELETE en /:id/notas-internas/*).
+mountNotaInternaRoutes(router, Prices, "Cotización Snack");
 
 //Enviar Cotización Snack
 router.post("/", async (req, res) => {
@@ -18,22 +22,24 @@ router.post("/", async (req, res) => {
   }
 });
 
-//Recuperar Datos Cotización Snack — admin ve todo, user solo sus propias
+//Recuperar Datos Cotización Snack — admin ve todo, user solo sus propias.
+// `notasInternas` se excluye para non-admin.
 router.get("/", requireAuth, async (req, res) => {
   try {
     const filter = req.user.role === "admin" ? {} : { userId: String(req.user._id) };
-    const pricesData = await Prices.find(filter);
+    const projection = req.user.role === "admin" ? "" : "-notasInternas";
+    const pricesData = await Prices.find(filter).select(projection);
     res.send({ message: "All Prices Snack", data: pricesData, total: pricesData.length });
   } catch (error) {
     res.status(400).send({ message: error });
   }
 });
 
-//Obtener Cotizaciones por ID Snack
+//Obtener Cotizaciones por ID Snack — endpoint público, esconde notas internas.
 router.get("/:id", async (req, res) => {
   try {
     const { id } = req.params;
-    const pricesid = await Prices.findById({ _id: id });
+    const pricesid = await Prices.findById({ _id: id }).select("-notasInternas");
     res.send({ message: "Price by ID Snack", data: pricesid });
   } catch (error) {
     res.status(400).send({ message: error });

--- a/src/utils/notaInternaRoute.js
+++ b/src/utils/notaInternaRoute.js
@@ -1,0 +1,75 @@
+const checkRoleToken = require("../middlewares/myRoleToken");
+
+/**
+ * Monta los endpoints de notas internas (POST + DELETE) sobre un router
+ * Express, asociados al `Model` dado. Reutilizable entre galletaPedido
+ * y las 3 cotizaciones (pastel/cupcake/snack).
+ *
+ * Endpoints montados (admin-only):
+ *   POST   /:id/notas-internas             agrega una nota
+ *   DELETE /:id/notas-internas/:notaId     borra una nota por su _id
+ *
+ * El autor de la nota se captura del JWT (`req.user`) — el cliente no
+ * puede falsificarlo.
+ *
+ * @param {express.Router} router  Router donde montar
+ * @param {mongoose.Model} Model   Modelo que tiene el array `notasInternas`
+ * @param {string} entidadLabel    Etiqueta para mensajes (ej. "Pedido", "Cotización")
+ */
+function mountNotaInternaRoutes(router, Model, entidadLabel = "Documento") {
+  // Agregar nota interna
+  router.post("/:id/notas-internas", checkRoleToken("admin"), async (req, res) => {
+    try {
+      const { texto } = req.body || {};
+      if (typeof texto !== "string" || !texto.trim()) {
+        return res.status(400).json({ message: "El campo 'texto' es obligatorio" });
+      }
+      const doc = await Model.findById(req.params.id);
+      if (!doc) return res.status(404).json({ message: `${entidadLabel} no encontrado` });
+
+      doc.notasInternas = doc.notasInternas || [];
+      doc.notasInternas.push({
+        texto: texto.trim(),
+        autorId:     req.user?._id ? String(req.user._id) : "",
+        autorNombre: req.user?.name || "",
+        autorEmail:  req.user?.email || "",
+      });
+      await doc.save();
+      const nuevaNota = doc.notasInternas[doc.notasInternas.length - 1];
+      res.status(201).json({
+        message: "Nota interna agregada",
+        data: nuevaNota,
+        total: doc.notasInternas.length,
+      });
+    } catch (error) {
+      console.error(`Error agregando nota interna a ${entidadLabel}:`, error);
+      res.status(400).json({ message: error.message });
+    }
+  });
+
+  // Borrar una nota interna por su _id
+  router.delete("/:id/notas-internas/:notaId", checkRoleToken("admin"), async (req, res) => {
+    try {
+      const doc = await Model.findById(req.params.id);
+      if (!doc) return res.status(404).json({ message: `${entidadLabel} no encontrado` });
+
+      const antes = (doc.notasInternas || []).length;
+      doc.notasInternas = (doc.notasInternas || []).filter(
+        (n) => String(n._id) !== String(req.params.notaId)
+      );
+      if (doc.notasInternas.length === antes) {
+        return res.status(404).json({ message: "Nota no encontrada" });
+      }
+      await doc.save();
+      res.json({
+        message: "Nota interna eliminada",
+        total: doc.notasInternas.length,
+      });
+    } catch (error) {
+      console.error(`Error eliminando nota interna en ${entidadLabel}:`, error);
+      res.status(400).json({ message: error.message });
+    }
+  });
+}
+
+module.exports = { mountNotaInternaRoutes };

--- a/src/utils/notaInternaRoute.js
+++ b/src/utils/notaInternaRoute.js
@@ -17,6 +17,22 @@ const checkRoleToken = require("../middlewares/myRoleToken");
  * @param {string} entidadLabel    Etiqueta para mensajes (ej. "Pedido", "Cotización")
  */
 function mountNotaInternaRoutes(router, Model, entidadLabel = "Documento") {
+  // Leer notas internas (admin-only). Necesario porque el GET /:id de
+  // cotizaciones es público y filtra notasInternas — el admin necesita
+  // esta ruta dedicada para verlas en el dashboard.
+  router.get("/:id/notas-internas", checkRoleToken("admin"), async (req, res) => {
+    try {
+      const doc = await Model.findById(req.params.id).select("notasInternas");
+      if (!doc) return res.status(404).json({ message: `${entidadLabel} no encontrado` });
+      res.json({
+        data: doc.notasInternas || [],
+        total: (doc.notasInternas || []).length,
+      });
+    } catch (error) {
+      res.status(400).json({ message: error.message });
+    }
+  });
+
   // Agregar nota interna
   router.post("/:id/notas-internas", checkRoleToken("admin"), async (req, res) => {
     try {


### PR DESCRIPTION
## Summary (back)

Cada Pedido de Galletas NY y cada Cotización (Pastel/Cupcake/Snack) ahora soporta **notas internas de admin** con historial. Caso de uso reportado: "cliente pagó por transferencia el 19/may" cuando el flujo Stripe no aplica, o "confirmó pickup por WhatsApp".

## Modelo de datos

Nuevo subdocumento embebido `notaInternaSchema`:

\`\`\`js
{
  texto: String (≤1000 chars, required),
  autorId: String,
  autorNombre: String,
  autorEmail: String,
  fecha: Date  // auto (createdAt renombrado)
}
\`\`\`

Embebido como array `notasInternas: [notaInternaSchema]` en los 4 modelos:
- `galletaPedido`
- `pastelCotiza`
- `cupcakesCotiza`
- `snackCotiza`

## Endpoints (admin-only)

Helper reutilizable \`mountNotaInternaRoutes(router, Model)\` monta:

| Método | Ruta | Acción |
|---|---|---|
| POST | \`/:id/notas-internas\` | Agrega nota. Body: \`{ texto }\`. Autor se captura del JWT |
| DELETE | \`/:id/notas-internas/:notaId\` | Borra nota por su _id |

Disponible bajo el prefijo de cada router:
- \`POST /galletaPedidos/:id/notas-internas\`
- \`POST /pricecake/:id/notas-internas\`
- \`POST /pricecupcake/:id/notas-internas\`
- \`POST /pricesnack/:id/notas-internas\`

## Seguridad — no leakear notas al cliente final

- **Cotizaciones `GET /`** (con auth) → para non-admin se aplica \`.select(\"-notasInternas\")\`.
- **Cotizaciones `GET /:id`** (público sin auth) → siempre \`.select(\"-notasInternas\")\`.
- **Galletas `GET /orden/:numeroOrden`** (público) → ya tenía whitelist, notas no estaban → sin cambio necesario.
- **Galletas `GET /`** y \`GET /:id\` → admin-only, ven todo.

## Diseño

- **Append-only desde UI**: el admin agrega notas, no las edita. Si hay typo, agregar una nota correctiva. Esto preserva el historial.
- **DELETE explícito** disponible por si se necesita borrar (no para UI normal, sí como escape hatch).
- **Autor del JWT**: el cliente no puede falsificar quién escribió la nota.
- **fecha auto**: \`timestamps: { createdAt: \"fecha\", updatedAt: false }\` — Mongoose lo setea sólito.

## Test plan en preview

- [ ] Como admin: POST a \`/galletaPedidos/:id/notas-internas\` con \`{ texto: \"Pagó por transferencia 19/may\" }\` → 201 + la nota con fecha y autor
- [ ] Volver a postear → segunda nota se agrega sin afectar la primera
- [ ] DELETE \`/galletaPedidos/:id/notas-internas/:notaId\` → 200, queda solo la otra nota
- [ ] Sin token o sin rol admin → 401/403
- [ ] Como user normal (no admin): GET \`/pricecake\` → en la respuesta los documentos NO tienen el campo \`notasInternas\`
- [ ] GET \`/pricecake/:id\` sin auth → respuesta NO contiene \`notasInternas\`

## Out of scope

- Frontend para mostrar/agregar notas en las páginas de detalle (PR aparte)

🤖 Generated with [Claude Code](https://claude.com/claude-code)