### PR TITLE
fix(galletas): 48h de anticipación + locale es en Stripe

### DIFF
--- a/src/routes/create-payment-intent/server.js
+++ b/src/routes/create-payment-intent/server.js
@@ -156,6 +156,7 @@ router.post("/create-checkout-session", requireAuth, async (req, res) => {
 
     const session = await stripe.checkout.sessions.create({
       ui_mode: "embedded",
+      locale: "es",
       line_items: [
         {
           price_data: {

--- a/src/routes/galletaPedidos.js
+++ b/src/routes/galletaPedidos.js
@@ -256,6 +256,7 @@ router.post("/checkout", async (req, res) => {
 
     const session = await stripe.checkout.sessions.create({
       ui_mode: "embedded",
+      locale: "es",
       line_items: lineItems,
       mode: "payment",
       return_url: `${FRONT_DOMAIN}/enduser/galletas-confirmacion?session_id={CHECKOUT_SESSION_ID}`,

--- a/src/utils/galletaSlots.js
+++ b/src/utils/galletaSlots.js
@@ -2,7 +2,7 @@
  * Utilidades para validar fechas y horarios de entrega de Galletas NY.
  *
  * Reglas:
- *  - Anticipación mínima: 72 horas desde el momento de la compra
+ *  - Anticipación mínima: 48 horas desde el momento de la compra
  *  - Días: Lunes a Sábado (no domingo)
  *  - Horarios:
  *      Recogida en sucursal: 10:00 a 18:30 (slots de 30 min)
@@ -24,7 +24,7 @@ const SLOTS_ENVIO = [
   "17:00", "17:30",
 ];
 
-const HORAS_72 = 72 * 60 * 60 * 1000;
+const HORAS_48 = 48 * 60 * 60 * 1000;
 
 /**
  * Devuelve los slots permitidos según tipo de entrega.
@@ -48,10 +48,10 @@ function validarFechaHora({ fecha, hora, tipoEntrega }) {
     return { ok: false, error: "Fecha inválida" };
   }
 
-  // 1) Mínimo 72h de anticipación.
+  // 1) Mínimo 48h de anticipación.
   const ahora = Date.now();
-  if (f.getTime() < ahora + HORAS_72) {
-    return { ok: false, error: "La fecha debe ser al menos 72 horas después de hoy" };
+  if (f.getTime() < ahora + HORAS_48) {
+    return { ok: false, error: "La fecha debe ser al menos 48 horas después de hoy" };
   }
 
   // 2) No domingos. (getDay: 0=Dom, 1=Lun, ..., 6=Sáb)


### PR DESCRIPTION
## Summary
- Anticipación mínima de entrega: **72h → 48h** en `validarFechaHora` (`src/utils/galletaSlots.js`).
- Stripe Checkout en **español explícito** (`locale: "es"`) en los 2 endpoints: galletas (`galletaPedidos.js`) y cotizaciones pastel/cupcake/snack (`create-payment-intent/server.js`).

## Contexto
- Reportado al probar en celular: la pasarela se mostraba en inglés porque el dispositivo estaba en inglés. Con `locale: "es"` Stripe ignora el idioma del navegador y siempre carga español.
- El error "fecha menor a 72 horas" venía del back; al bajar el umbral a 48h queda alineado con la regla de negocio.

## Test plan
- [ ] Hacer una compra de galletas con fecha = ahora + 49h → debe pasar la validación back.
- [ ] Hacer una compra con fecha = ahora + 47h → debe rechazar con "al menos 48 horas".
- [ ] Hacer una compra con fecha = próximo domingo → debe rechazar "No realizamos entregas los domingos".
- [ ] Confirmar que la pasarela Stripe carga en español en un dispositivo con idioma en inglés.
- [ ] Confirmar que cotizaciones (pastel/cupcake/snack) también muestran Stripe en español.

🤖 Generated with [Claude Code](https://claude.com/claude-code)