### PR TITLE
fix(galletas): regla 2 días hábiles de preparación

### DIFF
--- a/src/utils/galletaSlots.js
+++ b/src/utils/galletaSlots.js
@@ -2,11 +2,22 @@
  * Utilidades para validar fechas y horarios de entrega de Galletas NY.
  *
  * Reglas:
- *  - Anticipación mínima: 48 horas desde el momento de la compra
- *  - Días: Lunes a Sábado (no domingo)
+ *  - Anticipación mínima: 2 días hábiles completos de preparación entre el
+ *    día de la compra y el día de entrega. Domingo NO cuenta como día de
+ *    preparación (no se trabaja).
+ *  - Días de entrega: Lunes a Sábado (no domingo)
  *  - Horarios:
  *      Recogida en sucursal: 10:00 a 18:30 (slots de 30 min)
  *      Envío a domicilio:    11:00 a 17:30 (slots de 30 min)
+ *
+ * Ejemplos de primer día de entrega válido por día de compra:
+ *  - Lunes    → jueves     (martes, miércoles = 2 días prep)
+ *  - Martes   → viernes
+ *  - Miércoles→ sábado
+ *  - Jueves   → lunes      (viernes, sábado = 2 días prep; domingo skip)
+ *  - Viernes  → martes     (sábado, lunes = 2 días prep; domingo skip)
+ *  - Sábado   → miércoles  (lunes, martes = 2 días prep; domingo skip)
+ *  - Domingo  → miércoles  (lunes, martes = 2 días prep)
  */
 
 const SLOTS_RECOGIDA = [
@@ -24,13 +35,37 @@ const SLOTS_ENVIO = [
   "17:00", "17:30",
 ];
 
-const HORAS_48 = 48 * 60 * 60 * 1000;
+const DIAS_PREPARACION = 2;
 
 /**
  * Devuelve los slots permitidos según tipo de entrega.
  */
 function getSlotsValidos(tipoEntrega) {
   return tipoEntrega === "envio" ? SLOTS_ENVIO : SLOTS_RECOGIDA;
+}
+
+/**
+ * Dado un Date (fecha de compra/referencia, hora local GDL), devuelve el
+ * primer día de entrega válido como Date a medianoche local GDL.
+ *
+ * Lógica: a partir del día siguiente al de compra, contar `DIAS_PREPARACION`
+ * días hábiles (lunes-sábado), saltando domingos. El día de entrega es el
+ * SIGUIENTE día después de ese conteo. Si cae en domingo, saltar al lunes.
+ *
+ * @param {Date} desde — referencia (default: ahora)
+ * @returns {Date} primer día de entrega válido a 00:00 local GDL
+ */
+function primerDiaEntregaValido(desde = new Date()) {
+  const d = new Date(desde.getFullYear(), desde.getMonth(), desde.getDate());
+  let habilesAcumulados = 0;
+  while (habilesAcumulados < DIAS_PREPARACION) {
+    d.setDate(d.getDate() + 1);
+    if (d.getDay() !== 0) habilesAcumulados++;
+  }
+  // d es el último día de los 2 hábiles de preparación. Entrega = siguiente.
+  d.setDate(d.getDate() + 1);
+  if (d.getDay() === 0) d.setDate(d.getDate() + 1);
+  return d;
 }
 
 /**
@@ -52,8 +87,7 @@ function getSlotsValidos(tipoEntrega) {
  * @returns {{ok:true} | {ok:false, error:string}}
  */
 function validarFechaHora({ fecha, hora, tipoEntrega }) {
-  // 1) Hora debe ser un slot válido (lo validamos primero para que la
-  //    combinación fecha+hora abajo siempre tenga una hora bien formada).
+  // 1) Hora debe ser un slot válido.
   const slots = getSlotsValidos(tipoEntrega);
   if (!slots.includes(hora)) {
     return {
@@ -68,22 +102,32 @@ function validarFechaHora({ fecha, hora, tipoEntrega }) {
     return { ok: false, error: "Fecha inválida" };
   }
 
-  // 3) Construir el momento exacto de entrega en hora local GDL.
+  // 3) Construir el momento exacto de entrega y de "ahora" en hora local GDL.
+  //    Comparamos ambos a nivel de día (UTC-6) — qué tan temprano es la hora
+  //    no importa para la regla de 2 días hábiles, solo el día calendario.
   const fechaEntregaMs = Date.parse(`${fechaStr}T${hora}:00-06:00`);
   if (isNaN(fechaEntregaMs)) {
     return { ok: false, error: "Fecha inválida" };
   }
 
-  // 4) Mínimo 48h de anticipación contado desde ahora real.
-  const ahora = Date.now();
-  if (fechaEntregaMs < ahora + HORAS_48) {
-    return { ok: false, error: "La fecha de entrega debe ser al menos 48 horas después de ahora" };
+  // 4) Validar que sea >= primer día válido (regla 2 días hábiles).
+  //    Para calcular "hoy en GDL" desde un server UTC, construimos un Date
+  //    cuya partes (y,m,d) son las del momento actual en GDL.
+  const ahoraGdl = new Date(Date.now() - 6 * 60 * 60 * 1000); // UTC-6 sin DST
+  const minDate = primerDiaEntregaValido(
+    new Date(ahoraGdl.getUTCFullYear(), ahoraGdl.getUTCMonth(), ahoraGdl.getUTCDate())
+  );
+  const [y, m, d] = fechaStr.split("-").map(Number);
+  const fechaSoloDia = new Date(y, m - 1, d);
+  if (fechaSoloDia.getTime() < minDate.getTime()) {
+    return {
+      ok: false,
+      error: "La fecha de entrega requiere al menos 2 días hábiles de preparación (no contamos domingos)",
+    };
   }
 
-  // 5) No domingos. getDay() del Date local-construido es correcto a nivel
-  //    de día (no depende de la TZ del server).
-  const [y, m, d] = fechaStr.split("-").map(Number);
-  const dow = new Date(y, m - 1, d).getDay();
+  // 5) No domingos.
+  const dow = fechaSoloDia.getDay();
   if (dow === 0) {
     return { ok: false, error: "No realizamos entregas los domingos" };
   }
@@ -94,6 +138,8 @@ function validarFechaHora({ fecha, hora, tipoEntrega }) {
 module.exports = {
   SLOTS_RECOGIDA,
   SLOTS_ENVIO,
+  DIAS_PREPARACION,
   getSlotsValidos,
+  primerDiaEntregaValido,
   validarFechaHora,
 };


### PR DESCRIPTION
## Cambio de regla

Antes: 48h reales desde el momento de la compra.
Ahora: **2 días hábiles completos de preparación** entre el día de compra y el de entrega. Domingo NO cuenta como día de preparación.

## Razón

Con 48h reales, comprar el viernes ~19:00 permitía elegir el lunes a las 10:00 (63h) — pero esto solo dejaba al equipo el sábado para preparar (domingo no trabajan). Muy apretado.

Con la nueva regla, viernes → martes: sábado + lunes son 2 días completos de preparación.

## Tabla de primer día válido

| Día de compra | Primer día de entrega |
|---|---|
| Lunes | Jueves |
| Martes | Viernes |
| Miércoles | Sábado |
| Jueves | Lunes (viernes + sábado prep) |
| Viernes | Martes (sábado + lunes prep, domingo skip) |
| Sábado | Miércoles (lunes + martes prep) |
| Domingo | Miércoles |

## Implementación

- `primerDiaEntregaValido(desde)`: helper reutilizable que cuenta 2 días hábiles + 1 día de entrega, saltando domingos.
- Para calcular "hoy en GDL" desde Vercel (UTC), se compensa con `-6h` antes de extraer y/m/d.
- Acompaña [FrontPastelero#?](https://github.com/mipasteleria/FrontPastelero/pulls) que aplica la misma regla en el DatePicker.

## Test plan
- [ ] Comprar el viernes → solo elegible martes en adelante.
- [ ] Comprar el lunes → solo elegible jueves en adelante.
- [ ] Domingos siguen rechazados.
- [ ] Slots de hora inválidos siguen rechazados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)