### PR TITLE
feat(home-config): singleton para imagen del hero + hrefs editables

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ const productosRoutes = require("./src/routes/productos.js");
 const galletaSaboresRoutes = require("./src/routes/galletaSabores.js");
 const galletaPedidosRoutes = require("./src/routes/galletaPedidos.js");
 const calendarStatusRoutes = require("./src/routes/calendarStatus.js");
+const homeConfigRoutes = require("./src/routes/homeConfig.js");
 const createCheckoutSession = require("./src/routes/create-payment-intent/server.js");
 const stripeWebhook = require("./src/routes/create-payment-intent/webhook.js");
 const sendConfirmationEmail = require("./src/routes/create-payment-intent/confirmationEmail.js");
@@ -93,6 +94,7 @@ app.use("/galletaPedidos", galletaPedidosRoutes);
 app.use("/send-confirmation-email", sendConfirmationEmail);
 app.use("/notificaciones", notificacionesRoutes);
 app.use("/admin", calendarStatusRoutes);
+app.use("/home-config", homeConfigRoutes);
 app.get("/health", (req, res) => {
   res.json({ status: "ok", ts: Date.now() });
 });

--- a/src/models/homeConfig.js
+++ b/src/models/homeConfig.js
@@ -1,0 +1,26 @@
+const mongoose = require("mongoose");
+
+/**
+ * Configuración del home — singleton.
+ *
+ * Una sola doc en la colección. El admin la edita desde el dashboard y el
+ * front la consume para personalizar:
+ *   - Imagen central del hero (PNG sin fondo); fallback al emoji 🎂 si vacío.
+ *   - Destino del chip "Favorito de la semana" (a qué producto navega al
+ *     hacer click).
+ *   - Destino del chip "Nuevo sabor".
+ *
+ * Defaults apuntan a galletas NY para que el comportamiento sea razonable
+ * antes de que el admin configure nada.
+ */
+const homeConfigSchema = new mongoose.Schema(
+  {
+    imagenHeroUrl:      { type: String, default: "" },
+    imagenHeroFileName: { type: String, default: "" }, // para poder borrar del GCS
+    favoritoSemanaHref: { type: String, default: "/enduser/galletas-ny" },
+    nuevoSaborHref:     { type: String, default: "/enduser/galletas-ny" },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("HomeConfig", homeConfigSchema);

--- a/src/routes/homeConfig.js
+++ b/src/routes/homeConfig.js
@@ -1,0 +1,83 @@
+const express = require("express");
+const router = express.Router();
+const HomeConfig = require("../models/homeConfig");
+const checkRoleToken = require("../middlewares/myRoleToken");
+
+/**
+ * Singleton helper — devuelve la única doc de HomeConfig, creándola con
+ * defaults la primera vez. Así el front nunca recibe 404 y el admin no
+ * tiene que "crearla" manualmente.
+ */
+async function getOrCreateHomeConfig() {
+  let cfg = await HomeConfig.findOne();
+  if (!cfg) cfg = await HomeConfig.create({});
+  return cfg;
+}
+
+/**
+ * GET /home-config — público. Lo consume el index.jsx en cada render.
+ */
+router.get("/", async (req, res) => {
+  try {
+    const cfg = await getOrCreateHomeConfig();
+    res.json({
+      data: {
+        imagenHeroUrl:      cfg.imagenHeroUrl || "",
+        imagenHeroFileName: cfg.imagenHeroFileName || "",
+        favoritoSemanaHref: cfg.favoritoSemanaHref || "/enduser/galletas-ny",
+        nuevoSaborHref:     cfg.nuevoSaborHref || "/enduser/galletas-ny",
+      },
+    });
+  } catch (error) {
+    console.error("Error leyendo home-config:", error);
+    res.status(500).json({ message: error.message });
+  }
+});
+
+/**
+ * PUT /home-config — admin. Body acepta cualquier subconjunto de los
+ * campos editables (los no enviados se preservan).
+ *
+ * Para imagenHero, el flujo es:
+ *   1. Front sube archivo a POST /upload (que ya existe) → recibe { fileUrl, fileName }
+ *   2. Front envía PUT /home-config { imagenHeroUrl: fileUrl, imagenHeroFileName: fileName }
+ *
+ * Si se quiere "quitar" la imagen, enviar imagenHeroUrl: "" (también limpia fileName).
+ */
+router.put("/", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const cfg = await getOrCreateHomeConfig();
+    const { imagenHeroUrl, imagenHeroFileName, favoritoSemanaHref, nuevoSaborHref } = req.body || {};
+
+    if (typeof imagenHeroUrl === "string") {
+      cfg.imagenHeroUrl = imagenHeroUrl.trim();
+      // Si limpian la URL pero no mandaron fileName, también limpiar fileName.
+      if (!cfg.imagenHeroUrl) cfg.imagenHeroFileName = "";
+    }
+    if (typeof imagenHeroFileName === "string") {
+      cfg.imagenHeroFileName = imagenHeroFileName.trim();
+    }
+    if (typeof favoritoSemanaHref === "string") {
+      cfg.favoritoSemanaHref = favoritoSemanaHref.trim() || "/enduser/galletas-ny";
+    }
+    if (typeof nuevoSaborHref === "string") {
+      cfg.nuevoSaborHref = nuevoSaborHref.trim() || "/enduser/galletas-ny";
+    }
+
+    await cfg.save();
+    res.json({
+      message: "Configuración actualizada",
+      data: {
+        imagenHeroUrl:      cfg.imagenHeroUrl,
+        imagenHeroFileName: cfg.imagenHeroFileName,
+        favoritoSemanaHref: cfg.favoritoSemanaHref,
+        nuevoSaborHref:     cfg.nuevoSaborHref,
+      },
+    });
+  } catch (error) {
+    console.error("Error actualizando home-config:", error);
+    res.status(400).json({ message: error.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Resumen

Backend del feature \"editar el home desde el dashboard\":
- Imagen del hero (reemplaza el emoji 🎂 cuando hay imagen).
- Destino del chip \"Favorito de la semana\".
- Destino del chip \"Nuevo sabor\".

## Modelo
\`HomeConfig\` singleton (una sola doc):
- \`imagenHeroUrl\`, \`imagenHeroFileName\`
- \`favoritoSemanaHref\` (default: \`/enduser/galletas-ny\`)
- \`nuevoSaborHref\` (default: \`/enduser/galletas-ny\`)

## Endpoints
- \`GET /home-config\` — público; crea la doc con defaults si no existe.
- \`PUT /home-config\` — admin only; acepta cualquier subset de los campos.

## Imagen
No duplicamos infra de upload. El admin sube el PNG via \`POST /upload\` (que ya existe + GCS) → recibe \`{ fileUrl, fileName }\` → envía \`PUT /home-config\` con esos valores.

## Va con el PR del front
[FrontPastelero#?](https://github.com/mipasteleria/FrontPastelero/pulls) — añade el editor \`/dashboard/home-config\` y consume el GET en \`pages/index.jsx\`.

## Test plan
- [ ] \`GET /home-config\` sin doc previa → 200 con defaults.
- [ ] \`PUT /home-config\` con admin JWT y body \`{ favoritoSemanaHref: '/enduser/pastel-vintage' }\` → 200, valor persistido.
- [ ] \`PUT /home-config\` sin auth o con user → 401/403.
- [ ] \`PUT /home-config\` con \`imagenHeroUrl: ''\` también limpia \`imagenHeroFileName\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)