### PR TITLE
fix(gcs): quitar gzip + Content-Length que cortaban PNGs servidos

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,9 +221,14 @@ async function uploadFileToGCS(file, bucketName, req) {
   const bucket = storage.bucket(bucketName);
   const safeName = buildSafeFileName(file);
   const blob = bucket.file(safeName);
+  // NO usamos gzip:true. Las imágenes (PNG/JPG/WEBP) ya están comprimidas
+  // internamente, así que gzip encima no reduce nada y causa un bug
+  // sutil al servir vía proxy: `metadata.size` reporta el tamaño comprimido,
+  // `createReadStream()` descomprime al servir, y si seteamos Content-Length
+  // con metadata.size el browser corta el stream a mitad → el PNG se ve
+  // recortado horizontalmente.
   const blobStream = blob.createWriteStream({
     resumable: false,
-    gzip: true,
     metadata: {
       contentType: file.mimetype,
       cacheControl: "public, max-age=31536000, immutable",
@@ -303,7 +308,13 @@ app.get("/file/:filename", async (req, res) => {
     const [metadata] = await file.getMetadata();
     res.setHeader("Content-Type", metadata.contentType || "application/octet-stream");
     res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
-    if (metadata.size) res.setHeader("Content-Length", metadata.size);
+
+    // NO seteamos Content-Length manualmente. Si el archivo está
+    // gzipped en GCS (legacy de cuando uploadFileToGCS usaba gzip:true),
+    // metadata.size es el comprimido pero createReadStream descomprime
+    // al servir — el browser cortaría el stream al Content-Length
+    // declarado y la imagen llegaría truncada. Dejamos que Express/Node
+    // use Transfer-Encoding: chunked y el browser lee hasta EOF.
 
     file.createReadStream()
       .on("error", (e) => {


### PR DESCRIPTION
**Esto es lo que estaba cortando las imágenes** (no era Tailwind, ni `<img>`, ni el círculo, ni el tamaño del upload):

```
uploadFileToGCS:  gzip: true       → GCS comprime el archivo en storage
                                    metadata.size = tamaño COMPRIMIDO
proxy /file:      setHeader        → Content-Length: metadata.size (comprimido)
                  createReadStream → descomprime al servir, envía + bytes
browser:                           → corta el stream a Content-Length
                                    → scanlines posteriores nunca llegan
                                    → corte horizontal recto en el PNG
```

PNG y JPG ya están comprimidos internamente — gzip encima no reduce nada y solo causa este bug.

**Fix:**
- Quitar `gzip: true` del upload (futuros archivos sin compresión extra).
- Quitar `res.setHeader('Content-Length', metadata.size)` del proxy. Sin él, Node usa Transfer-Encoding: chunked y el browser lee hasta EOF — sirve correctamente tanto archivos viejos (con gzip legacy) como los nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)