### PR TITLE
feat(postres): Fase 1 — modelo + CRUD admin + endpoints públicos

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const galletaSaboresRoutes = require("./src/routes/galletaSabores.js");
 const galletaPedidosRoutes = require("./src/routes/galletaPedidos.js");
 const calendarStatusRoutes = require("./src/routes/calendarStatus.js");
 const homeConfigRoutes = require("./src/routes/homeConfig.js");
+const postresRoutes = require("./src/routes/postres.js");
 const createCheckoutSession = require("./src/routes/create-payment-intent/server.js");
 const stripeWebhook = require("./src/routes/create-payment-intent/webhook.js");
 const sendConfirmationEmail = require("./src/routes/create-payment-intent/confirmationEmail.js");
@@ -95,6 +96,7 @@ app.use("/send-confirmation-email", sendConfirmationEmail);
 app.use("/notificaciones", notificacionesRoutes);
 app.use("/admin", calendarStatusRoutes);
 app.use("/home-config", homeConfigRoutes);
+app.use("/postres", postresRoutes);
 app.get("/health", (req, res) => {
   res.json({ status: "ok", ts: Date.now() });
 });

--- a/src/models/postre.js
+++ b/src/models/postre.js
@@ -1,0 +1,56 @@
+const mongoose = require("mongoose");
+
+/**
+ * Postre del catálogo "Top postres".
+ *
+ * A diferencia de las cotizaciones personalizadas, estos son productos
+ * con precio fijo que el cliente puede comprar directamente desde el
+ * catálogo (similar al flujo de Galletas NY pero por unidad, sin variantes
+ * y sin stock — se preparan bajo pedido).
+ *
+ * El campo `slug` es un identificador estable usado en URLs públicas
+ * (ej. /enduser/postres/pay-de-pistache) y en los pedidos.
+ *
+ * El admin marca hasta 4 postres como `destacado: true`, que son los que
+ * aparecen en la sección "Los más horneados" del home. La validación de
+ * "no más de 4 destacados" vive en el controller, no en el schema, para
+ * que pueda devolver un 400 con mensaje claro.
+ */
+const postreSchema = new mongoose.Schema(
+  {
+    slug: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+      match: [/^[a-z0-9-]+$/, "Slug solo permite minúsculas, números y guiones"],
+    },
+    nombre:      { type: String, required: true, trim: true },
+    descripcion: { type: String, trim: true, default: "" },
+
+    precio: {
+      type: Number,
+      required: true,
+      min: [0, "Precio no puede ser negativo"],
+    },
+
+    // Imagen del producto. fileName se guarda para poder borrar el blob
+    // de GCS cuando se reemplaza o se elimina el postre (evita huérfanos).
+    imagenUrl:      { type: String, default: "" },
+    imagenFileName: { type: String, default: "" },
+
+    // Soft-delete: activo=false oculta del catálogo público pero conserva
+    // historial para reportes y pedidos antiguos que referencien el postre.
+    activo:    { type: Boolean, default: true },
+    destacado: { type: Boolean, default: false },
+
+    orden: { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+// Index para la query del home (los 4 destacados activos).
+postreSchema.index({ activo: 1, destacado: 1, orden: 1 });
+
+module.exports = mongoose.model("Postre", postreSchema);

--- a/src/routes/postres.js
+++ b/src/routes/postres.js
@@ -1,0 +1,200 @@
+const express = require("express");
+const router = express.Router();
+const { Storage } = require("@google-cloud/storage");
+const Postre = require("../models/postre");
+const checkRoleToken = require("../middlewares/myRoleToken");
+
+const MAX_DESTACADOS = 4;
+
+// Cliente GCS local para borrar archivos huérfanos al reemplazar o
+// eliminar postres (mismo patrón que homeConfig.js).
+let gcs = null;
+try {
+  const credentials = process.env.GCS_CREDENTIALS ? JSON.parse(process.env.GCS_CREDENTIALS) : undefined;
+  gcs = new Storage({ projectId: process.env.PROJECT_ID, credentials });
+} catch (e) {
+  console.error("[postres] GCS init failed — cleanup disabled:", e.message);
+}
+const BUCKET = process.env.BUCKET_NAME;
+
+async function borrarArchivoGCS(fileName) {
+  if (!gcs || !BUCKET || !fileName) return;
+  try {
+    await gcs.bucket(BUCKET).file(fileName).delete({ ignoreNotFound: true });
+  } catch (e) {
+    console.error(`[postres] No se pudo borrar archivo ${fileName}:`, e.message);
+  }
+}
+
+// Whitelist de campos editables — evita que el cliente mande _id,
+// createdAt, etc. en un POST/PUT y los sobrescriba.
+const CAMPOS_EDITABLES = [
+  "slug",
+  "nombre",
+  "descripcion",
+  "precio",
+  "imagenUrl",
+  "imagenFileName",
+  "activo",
+  "destacado",
+  "orden",
+];
+
+function pickEditables(body) {
+  const out = {};
+  for (const k of CAMPOS_EDITABLES) {
+    if (Object.prototype.hasOwnProperty.call(body || {}, k)) out[k] = body[k];
+  }
+  return out;
+}
+
+/**
+ * GET /postres — listado.
+ *
+ * Público por default solo devuelve `activo: true`. Si el admin pasa
+ * ?incluyeInactivos=true, devuelve todos (no validamos rol aquí porque
+ * es una query opcional; si se filtra el catálogo público, no hay nada
+ * que filtrar para inactivos).
+ *
+ * ?destacado=true filtra solo los destacados (atajo del home).
+ */
+router.get("/", async (req, res) => {
+  try {
+    const filter = {};
+    if (req.query.incluyeInactivos !== "true") filter.activo = true;
+    if (req.query.destacado === "true") filter.destacado = true;
+
+    const postres = await Postre.find(filter).sort({ orden: 1, createdAt: -1 });
+    res.json({ data: postres });
+  } catch (e) {
+    console.error("Error listando postres:", e);
+    res.status(500).json({ message: e.message });
+  }
+});
+
+/**
+ * GET /postres/destacados — atajo público para el home.
+ * Devuelve hasta 4 postres activos marcados como destacado.
+ */
+router.get("/destacados", async (req, res) => {
+  try {
+    const postres = await Postre.find({ activo: true, destacado: true })
+      .sort({ orden: 1, createdAt: -1 })
+      .limit(MAX_DESTACADOS);
+    res.json({ data: postres });
+  } catch (e) {
+    console.error("Error obteniendo destacados:", e);
+    res.status(500).json({ message: e.message });
+  }
+});
+
+/**
+ * GET /postres/:idOrSlug — detalle.
+ * Acepta ObjectId (admin) o slug (URLs públicas amigables).
+ */
+router.get("/:idOrSlug", async (req, res) => {
+  try {
+    const { idOrSlug } = req.params;
+    const isObjectId = /^[0-9a-fA-F]{24}$/.test(idOrSlug);
+    const postre = isObjectId
+      ? await Postre.findById(idOrSlug)
+      : await Postre.findOne({ slug: idOrSlug });
+    if (!postre) return res.status(404).json({ message: "Postre no encontrado" });
+    res.json({ data: postre });
+  } catch (e) {
+    console.error("Error obteniendo postre:", e);
+    res.status(500).json({ message: e.message });
+  }
+});
+
+/**
+ * POST /postres — admin: crear.
+ * Si `destacado: true`, valida que no excedamos MAX_DESTACADOS.
+ */
+router.post("/", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const data = pickEditables(req.body);
+
+    if (data.destacado) {
+      const count = await Postre.countDocuments({ destacado: true, activo: true });
+      if (count >= MAX_DESTACADOS) {
+        return res.status(400).json({
+          message: `Ya hay ${MAX_DESTACADOS} postres destacados. Quita uno antes de marcar este.`,
+        });
+      }
+    }
+
+    const postre = await Postre.create(data);
+    res.status(201).json({ message: "Postre creado", data: postre });
+  } catch (e) {
+    if (e.code === 11000) {
+      return res.status(409).json({ message: "Ya existe un postre con ese slug" });
+    }
+    console.error("Error creando postre:", e);
+    res.status(400).json({ message: e.message });
+  }
+});
+
+/**
+ * PUT /postres/:id — admin: editar.
+ * Si la imagen cambia, borra el archivo previo de GCS.
+ * Si se marca como destacado, valida MAX_DESTACADOS (excluyendo a sí mismo).
+ */
+router.put("/:id", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const previo = await Postre.findById(req.params.id);
+    if (!previo) return res.status(404).json({ message: "Postre no encontrado" });
+
+    const fileNamePrevio = previo.imagenFileName || "";
+    const data = pickEditables(req.body);
+
+    // Si se está marcando como destacado (y no lo era), validar tope.
+    if (data.destacado === true && !previo.destacado) {
+      const count = await Postre.countDocuments({
+        destacado: true,
+        activo: true,
+        _id: { $ne: previo._id },
+      });
+      if (count >= MAX_DESTACADOS) {
+        return res.status(400).json({
+          message: `Ya hay ${MAX_DESTACADOS} postres destacados. Quita uno antes de marcar este.`,
+        });
+      }
+    }
+
+    Object.assign(previo, data);
+    await previo.save();
+
+    // Cleanup de imagen previa si fue reemplazada o limpiada.
+    if (fileNamePrevio && fileNamePrevio !== previo.imagenFileName) {
+      borrarArchivoGCS(fileNamePrevio); // fire-and-forget
+    }
+
+    res.json({ message: "Postre actualizado", data: previo });
+  } catch (e) {
+    if (e.code === 11000) {
+      return res.status(409).json({ message: "Ya existe un postre con ese slug" });
+    }
+    console.error("Error actualizando postre:", e);
+    res.status(400).json({ message: e.message });
+  }
+});
+
+/**
+ * DELETE /postres/:id — admin: borrar.
+ * Hard-delete + cleanup de imagen en GCS.
+ * Si se quiere conservar el postre para histórico, marcarlo activo:false en su lugar.
+ */
+router.delete("/:id", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const postre = await Postre.findByIdAndDelete(req.params.id);
+    if (!postre) return res.status(404).json({ message: "Postre no encontrado" });
+    if (postre.imagenFileName) borrarArchivoGCS(postre.imagenFileName);
+    res.json({ message: "Postre eliminado" });
+  } catch (e) {
+    console.error("Error eliminando postre:", e);
+    res.status(400).json({ message: e.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
Fase 1 de 4 del feature "Top postres" del home.

## Modelo `Postre`
Producto simple con precio fijo. Decisiones de diseño (sesión con Alberto):
- Sin stock (bajo pedido)
- Sin variantes (cada tamaño/sabor = postre separado)
- Soft-delete (`activo: true/false`)
- `destacado` con tope de 4 (los que aparecen en el home)

## Endpoints `/postres`
| Verbo | Ruta | Auth | Notas |
|---|---|---|---|
| GET | `/` | público | default solo `activo: true`; `?destacado=true` filtra |
| GET | `/destacados` | público | atajo del home (activos + destacados, max 4) |
| GET | `/:idOrSlug` | público | acepta ObjectId o slug |
| POST | `/` | admin | valida MAX_DESTACADOS=4 |
| PUT | `/:id` | admin | cleanup GCS si cambia imagen + valida tope destacados |
| DELETE | `/:id` | admin | hard-delete + cleanup GCS |

## Cleanup GCS
Reusa el patrón de `homeConfig`: si la imagen cambia o el postre se elimina, el blob previo se borra del bucket en fire-and-forget. Evita huérfanos.

## Próximas fases (PRs siguientes)
- **Fase 2**: admin `/dashboard/postres` (lista + crear/editar/borrar + toggle destacado).
- **Fase 3**: catálogo público `/enduser/postres` + integrar destacados en "Los más horneados" del home.
- **Fase 4**: carrito unificado + checkout Stripe + emails + Calendar (la grande).

## Test plan
- [ ] `POST /postres` con admin JWT y body válido → 201 con la doc creada.
- [ ] `POST /postres` sin auth o con user → 401/403.
- [ ] `POST /postres` con `slug` duplicado → 409.
- [ ] Crear 4 con `destacado: true`, intentar un 5to con `destacado: true` → 400 con mensaje claro.
- [ ] `GET /postres` público sin filtros → solo activos.
- [ ] `GET /postres/destacados` → max 4 activos+destacados.
- [ ] `PUT /:id` cambiando `imagenFileName` → el archivo previo desaparece del bucket.
- [ ] `DELETE /:id` → blob también se borra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)