### PR TITLE
feat(recetas): horas de mano de obra + gastos fijos (back)

### DIFF
--- a/src/jobs/costeoHandler.js
+++ b/src/jobs/costeoHandler.js
@@ -48,7 +48,16 @@ async function calcularCosteo(cotizacion, porciones, body) {
     tecnicasSnapshot.reduce((s, t) => s + t.costoCalculado, 0)
   );
 
-  const costoTotal = round2(costoReceta + costoTecnicasTotal + costoFijo);
+  // Compat con recetas legacy: las nuevas guardan en `total_cost` el costo
+  // COMPLETO (ingredientes + IEPS + additional + mano_obra + fijos). Las
+  // viejas (sin hours_labor ni hours_fixed) guardan solo el bruto, así que
+  // les sumamos `costoFijo` plano como se hacía antes para no romper su
+  // cálculo histórico.
+  const esRecetaNueva =
+    typeof receta.hours_labor === "number" || typeof receta.hours_fixed === "number";
+  const overheadLegacy = esRecetaNueva ? 0 : costoFijo;
+
+  const costoTotal = round2(costoReceta + costoTecnicasTotal + overheadLegacy);
 
   const precioSugerido = round2(costoTotal * (1 + margenDeseado / 100));
   const ivaImporte = round2(precioSugerido * (ivaPercent / 100));

--- a/src/models/recetas/recetas.js
+++ b/src/models/recetas/recetas.js
@@ -22,15 +22,38 @@ const recetaSchema = new mongoose.Schema(
       required: [true, "El número de porciones es obligatorio"],
       match: [/^\d+$/, "Número de porciones no válido"],
     },
+
+    // ── Snapshots de tarifas globales al momento de guardar la receta ──
+    // (legacy: el nombre `fixed_costs_hours` confunde — guardaba la
+    // tarifa horaria de mano de obra, no horas. Se mantiene por compat
+    // con recetas existentes; el cálculo real usa los nuevos campos
+    // `hours_labor` y `hours_fixed` cuando están definidos.)
     fixed_costs_hours: {
       type: Number,
-      required: [true, "Los gastos fijos en horas son obligatorios"],
-      match: [/^\d+(\.\d+)?$/, "Gastos fijos en horas no válidos"], // Permite decimales
+      required: false, // legacy: era requerido cuando guardaba la tarifa
     },
     fixed_costs: {
       type: Number,
-      required: [true, "Los gastos fijos son obligatorios"],
+      required: false, // legacy: ver comentario arriba
     },
+
+    // ── Nuevos campos para costeo correcto ──
+    // Horas de mano de obra usadas en la receta. Se multiplican por
+    // la tarifa horaria (`Cost.laborCosts`) para obtener el costo de
+    // mano de obra real de la receta.
+    hours_labor: {
+      type: Number,
+      default: 0,
+      min: [0, "Las horas no pueden ser negativas"],
+    },
+    // Horas de uso del taller (gastos fijos). Multiplican por
+    // `Cost.fixedCosts` (tarifa horaria) para obtener los fijos.
+    hours_fixed: {
+      type: Number,
+      default: 0,
+      min: [0, "Las horas no pueden ser negativas"],
+    },
+
     special_tax: {
       type: Number,
       required: [true, "El IEPS es obligatorio"],
@@ -42,7 +65,7 @@ const recetaSchema = new mongoose.Schema(
     total_cost: {
       type: Number,
       required: [true, "El costo total es obligatorio"],
-      match: [/^\d+(\.\d+)?$/, "Gastos fijos en horas no válidos"], // Permite decimales
+      match: [/^\d+(\.\d+)?$/, "Costo total no válido"],
     },
   },
   {


### PR DESCRIPTION
## Cambios
- **Modelo Receta**: agrega `hours_labor` (horas mano de obra) + `hours_fixed` (horas taller). Defaults 0, opcionales. Hace opcionales los legacy `fixed_costs` y `fixed_costs_hours` (nombres confusos que no eran horas).
- **costeoHandler**:
  - Recetas nuevas (con `hours_*` definidos): `total_cost` ya incluye overhead → handler no suma `costoFijo` aparte.
  - Recetas legacy (sin `hours_*`): sigue sumando `costoFijo` plano como antes → preserva cálculos históricos.

Va con el PR del front que actualiza el form de receta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)