### PR TITLE
feat(postres): precio sugerido desde receta + branding + empaque (back)

### DIFF
--- a/src/models/costs.js
+++ b/src/models/costs.js
@@ -30,6 +30,23 @@ const costSchema = new mongoose.Schema({
     default: 5,
     min: 0,
   },
+
+  // ── Postres: configuración global ──────────────────────────────
+  // Branding por postre — análogo al de galletas pero separado por si
+  // el costo varía (ej. etiqueta más grande, sticker premium). El
+  // empaque NO va aquí porque varía por postre (domo, caja, etc.).
+  costoBrandingPorPostre: {
+    type: Number,
+    default: 0,
+    min: 0,
+  },
+  // Markup default para postres cuando la receta no tiene profit_margin
+  // o el admin no lo override en el form de postre.
+  markupPostresPct: {
+    type: Number,
+    default: 60,
+    min: 0,
+  },
 });
 
 module.exports = mongoose.model("Cost", costSchema);

--- a/src/models/postre.js
+++ b/src/models/postre.js
@@ -35,6 +35,24 @@ const postreSchema = new mongoose.Schema(
       min: [0, "Precio no puede ser negativo"],
     },
 
+    // ── Costeo opcional desde receta ──────────────────────────────
+    // Si `recetaId` está presente, el sistema puede sugerir un precio
+    // basado en (receta.total_cost / receta.portions) + branding global
+    // + empaque de este postre + markup. Es informativo — el admin
+    // puede usar el sugerido o setear `precio` manualmente.
+    recetaId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Receta",
+      default: null,
+    },
+    // Empaque varía por postre (domo, caja, base de cartón, etc.).
+    // Se suma al costo unitario antes de aplicar el markup.
+    costoEmpaque: {
+      type: Number,
+      default: 0,
+      min: [0, "El costo de empaque no puede ser negativo"],
+    },
+
     // Imagen del producto. fileName se guarda para poder borrar el blob
     // de GCS cuando se reemplaza o se elimina el postre (evita huérfanos).
     imagenUrl:      { type: String, default: "" },

--- a/src/routes/costs.js
+++ b/src/routes/costs.js
@@ -89,6 +89,7 @@ router.put('/', checkRoleToken('admin'), async (req, res) => {
     const {
       fixedCosts, laborCosts,
       costoBrandingPorGalleta, markupGalletasPct, margenMinimoGalleta,
+      costoBrandingPorPostre, markupPostresPct,
     } = req.body;
     if (fixedCosts === undefined || laborCosts === undefined) {
       return res.status(400).json({ message: "Parámetros 'fixedCosts' y 'laborCosts' son requeridos" });
@@ -97,6 +98,8 @@ router.put('/', checkRoleToken('admin'), async (req, res) => {
     if (costoBrandingPorGalleta !== undefined) update.costoBrandingPorGalleta = costoBrandingPorGalleta;
     if (markupGalletasPct       !== undefined) update.markupGalletasPct       = markupGalletasPct;
     if (margenMinimoGalleta     !== undefined) update.margenMinimoGalleta     = margenMinimoGalleta;
+    if (costoBrandingPorPostre  !== undefined) update.costoBrandingPorPostre  = costoBrandingPorPostre;
+    if (markupPostresPct        !== undefined) update.markupPostresPct        = markupPostresPct;
     const cost = await Cost.findOneAndUpdate(
       {},
       update,

--- a/src/routes/postres.js
+++ b/src/routes/postres.js
@@ -2,9 +2,60 @@ const express = require("express");
 const router = express.Router();
 const { Storage } = require("@google-cloud/storage");
 const Postre = require("../models/postre");
+const Receta = require("../models/recetas/recetas");
+const Cost = require("../models/costs");
 const checkRoleToken = require("../middlewares/myRoleToken");
 
 const MAX_DESTACADOS = 4;
+
+function round2(n) { return Math.round(n * 100) / 100; }
+
+/**
+ * Calcula el desglose de precio sugerido para un postre, dada una
+ * receta + empaque del postre + config global. Reusa el patrón de
+ * galletaSabores.calcular-precio pero con empaque por postre.
+ */
+async function calcularDesglosePostre({ recetaId, costoEmpaque = 0, markupPctOverride } = {}) {
+  const receta = await Receta.findById(recetaId);
+  if (!receta) throw new Error("Receta no encontrada");
+  if (!receta.portions || receta.portions <= 0) {
+    throw new Error("La receta no tiene `portions` válido");
+  }
+
+  const cfg = await Cost.findOne();
+  const costoBranding = cfg?.costoBrandingPorPostre ?? 0;
+  const markupDefault = cfg?.markupPostresPct ?? 60;
+
+  // Prioridad de markup: override del body > profit_margin de la receta > default global.
+  let markup;
+  if (typeof markupPctOverride === "number" && markupPctOverride >= 0) {
+    markup = markupPctOverride;
+  } else if (typeof receta.profit_margin === "number" && receta.profit_margin >= 0) {
+    markup = receta.profit_margin;
+  } else {
+    markup = markupDefault;
+  }
+
+  const costoMateriaPrima = round2(receta.total_cost / receta.portions);
+  const empaque = Number(costoEmpaque) || 0;
+  const costoTotal = round2(costoMateriaPrima + costoBranding + empaque);
+  const precioSugerido = round2(costoTotal * (1 + markup / 100));
+
+  return {
+    receta: {
+      _id: receta._id,
+      nombre_receta: receta.nombre_receta,
+      portions: receta.portions,
+      total_cost: receta.total_cost,
+    },
+    costoMateriaPrima,
+    costoBranding,
+    costoEmpaque: empaque,
+    costoTotal,
+    markupPct: markup,
+    precioSugerido,
+  };
+}
 
 // Cliente GCS local para borrar archivos huérfanos al reemplazar o
 // eliminar postres (mismo patrón que homeConfig.js).
@@ -38,6 +89,8 @@ const CAMPOS_EDITABLES = [
   "activo",
   "destacado",
   "orden",
+  "recetaId",
+  "costoEmpaque",
 ];
 
 function pickEditables(body) {
@@ -85,6 +138,34 @@ router.get("/destacados", async (req, res) => {
   } catch (e) {
     console.error("Error obteniendo destacados:", e);
     res.status(500).json({ message: e.message });
+  }
+});
+
+/**
+ * POST /postres/calcular-precio — admin.
+ *
+ * Dado { recetaId, costoEmpaque, markupPct? }, devuelve un breakdown
+ * del precio sugerido para un postre. NO modifica nada — solo calcula
+ * en base a la receta y la config global. El admin decide si usa el
+ * sugerido o setea `precio` manualmente al guardar el postre.
+ *
+ * Análogo a POST /galletaSabores/calcular-precio pero con empaque
+ * variable por postre (no por catálogo global como branding).
+ */
+router.post("/calcular-precio", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const { recetaId, costoEmpaque, markupPct } = req.body || {};
+    if (!recetaId) return res.status(400).json({ message: "recetaId es requerido" });
+
+    const data = await calcularDesglosePostre({
+      recetaId,
+      costoEmpaque,
+      markupPctOverride: typeof markupPct === "number" ? markupPct : undefined,
+    });
+    res.json({ message: "Precio calculado", data });
+  } catch (e) {
+    console.error("Error calculando precio postre:", e);
+    res.status(400).json({ message: e.message });
   }
 });
 


### PR DESCRIPTION
## Resumen

Replica el patrón de `galletaSabores.calcular-precio` para postres, con la diferencia clave de que el **empaque es por postre** (no global como el branding) — un postre lleva domo, otro caja, etc.

## Cambios
- **Cost**: `costoBrandingPorPostre` + `markupPostresPct` (separados de los de galletas).
- **Postre**: `recetaId` (opcional) + `costoEmpaque` (por postre).
- **POST /postres/calcular-precio** (admin): dado `{ recetaId, costoEmpaque, markupPct? }` devuelve breakdown:
  - `costoMateriaPrima = receta.total_cost / receta.portions`
  - `+ costoBranding` (global)
  - `+ costoEmpaque` (por postre, del body)
  - `= costoTotal`
  - `× (1 + markup/100)` = `precioSugerido`
- Markup: override del body > `receta.profit_margin` > `markupPostresPct` global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)