### PR TITLE
feat(postres): cantidadReceta para porciones parciales

### DIFF
--- a/src/models/postre.js
+++ b/src/models/postre.js
@@ -37,13 +37,23 @@ const postreSchema = new mongoose.Schema(
 
     // ── Costeo opcional desde receta ──────────────────────────────
     // Si `recetaId` está presente, el sistema puede sugerir un precio
-    // basado en (receta.total_cost / receta.portions) + branding global
-    // + empaque de este postre + markup. Es informativo — el admin
+    // basado en (receta.total_cost / receta.portions) × cantidadReceta
+    // + branding global + empaque + markup. Es informativo — el admin
     // puede usar el sugerido o setear `precio` manualmente.
     recetaId: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "Receta",
       default: null,
+    },
+    // Cuántas unidades de la receta consume un postre. Default 1 (un
+    // postre = 1 porción/pieza). Permite postres como "Rosca de naranja"
+    // que usa 20 porciones de una receta que rinde 40 porciones, o un
+    // "Bote de mermelada" que usa 100g de una receta que rinde 500g.
+    // La unidad la dicta `receta.unidadRendimiento`.
+    cantidadReceta: {
+      type: Number,
+      default: 1,
+      min: [0, "La cantidad no puede ser negativa"],
     },
     // Empaque varía por postre (domo, caja, base de cartón, etc.).
     // Se suma al costo unitario antes de aplicar el markup.

--- a/src/routes/postres.js
+++ b/src/routes/postres.js
@@ -15,7 +15,7 @@ function round2(n) { return Math.round(n * 100) / 100; }
  * receta + empaque del postre + config global. Reusa el patrón de
  * galletaSabores.calcular-precio pero con empaque por postre.
  */
-async function calcularDesglosePostre({ recetaId, costoEmpaque = 0, markupPctOverride } = {}) {
+async function calcularDesglosePostre({ recetaId, costoEmpaque = 0, cantidadReceta = 1, markupPctOverride } = {}) {
   const receta = await Receta.findById(recetaId);
   if (!receta) throw new Error("Receta no encontrada");
   if (!receta.portions || receta.portions <= 0) {
@@ -36,7 +36,12 @@ async function calcularDesglosePostre({ recetaId, costoEmpaque = 0, markupPctOve
     markup = markupDefault;
   }
 
-  const costoMateriaPrima = round2(receta.total_cost / receta.portions);
+  // Materia prima = costo unitario de la receta × cuántas unidades usa
+  // este postre. Por ejemplo si la receta rinde 40 porciones y este
+  // postre usa 20, materia prima = (total_cost / 40) × 20 = total_cost / 2.
+  const cantidad = Math.max(0, Number(cantidadReceta) || 1);
+  const costoUnitarioReceta = receta.total_cost / receta.portions;
+  const costoMateriaPrima = round2(costoUnitarioReceta * cantidad);
   const empaque = Number(costoEmpaque) || 0;
   const costoTotal = round2(costoMateriaPrima + costoBranding + empaque);
   const precioSugerido = round2(costoTotal * (1 + markup / 100));
@@ -47,7 +52,10 @@ async function calcularDesglosePostre({ recetaId, costoEmpaque = 0, markupPctOve
       nombre_receta: receta.nombre_receta,
       portions: receta.portions,
       total_cost: receta.total_cost,
+      unidadRendimiento: receta.unidadRendimiento || "porcion",
     },
+    cantidadReceta: cantidad,
+    costoUnitarioReceta: round2(costoUnitarioReceta),
     costoMateriaPrima,
     costoBranding,
     costoEmpaque: empaque,
@@ -90,6 +98,7 @@ const CAMPOS_EDITABLES = [
   "destacado",
   "orden",
   "recetaId",
+  "cantidadReceta",
   "costoEmpaque",
 ];
 
@@ -154,12 +163,13 @@ router.get("/destacados", async (req, res) => {
  */
 router.post("/calcular-precio", checkRoleToken("admin"), async (req, res) => {
   try {
-    const { recetaId, costoEmpaque, markupPct } = req.body || {};
+    const { recetaId, costoEmpaque, cantidadReceta, markupPct } = req.body || {};
     if (!recetaId) return res.status(400).json({ message: "recetaId es requerido" });
 
     const data = await calcularDesglosePostre({
       recetaId,
       costoEmpaque,
+      cantidadReceta,
       markupPctOverride: typeof markupPct === "number" ? markupPct : undefined,
     });
     res.json({ message: "Precio calculado", data });


### PR DESCRIPTION
Caso de Alberto: receta "Pan de naranja" rinde 40 porciones, pero el postre "Rosca" usa 20 porciones. Antes el cálculo asumía 1 postre = 1 unidad de la receta.

## Cambios
- **Postre.cantidadReceta** (default 1). Cuántas unidades del rendimiento de la receta consume un postre.
- **calcular-precio**: `costoMateriaPrima = (total_cost / portions) × cantidadReceta`.
- Response incluye `cantidadReceta` y `costoUnitarioReceta` para que el front muestre el desglose.

**Backward compat**: postres existentes tienen `cantidadReceta = 1` por default → cálculo idéntico.

Va con el PR del front que expone el campo en el form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)