### PR TITLE
feat(cotizacion): Fase A back — catálogos + modelo CotizacionPersonalizada

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,8 @@ const homeConfigRoutes = require("./src/routes/homeConfig.js");
 const postresRoutes = require("./src/routes/postres.js");
 const postrePedidosRoutes = require("./src/routes/postrePedidos.js");
 const resenasRoutes = require("./src/routes/resenas.js");
+const cotizacionCatalogosRoutes = require("./src/routes/cotizacionCatalogos");
+const cotizacionPersonalizadaRoutes = require("./src/routes/cotizacionPersonalizada.js");
 const createCheckoutSession = require("./src/routes/create-payment-intent/server.js");
 const stripeWebhook = require("./src/routes/create-payment-intent/webhook.js");
 const sendConfirmationEmail = require("./src/routes/create-payment-intent/confirmationEmail.js");
@@ -101,6 +103,8 @@ app.use("/home-config", homeConfigRoutes);
 app.use("/postres", postresRoutes);
 app.use("/postrePedidos", postrePedidosRoutes);
 app.use("/resenas", resenasRoutes);
+app.use("/cotizacion-catalogos", cotizacionCatalogosRoutes);
+app.use("/cotizacion-personalizada", cotizacionPersonalizadaRoutes);
 app.get("/health", (req, res) => {
   res.json({ status: "ok", ts: Date.now() });
 });

--- a/src/models/cotizacionCatalogos/cobertura.js
+++ b/src/models/cotizacionCatalogos/cobertura.js
@@ -1,0 +1,38 @@
+const mongoose = require("mongoose");
+
+/**
+ * Cobertura del pastel (buttercream, ganache, fondant, etc.).
+ *
+ * Similar a relleno: catálogo plano con costo manual. La bandera
+ * `esFondant` permite al front pintar el toggle especial de la maqueta
+ * (fondant suele tener costo extra significativo). El campo
+ * `costoExtraSiFondant` no se usa hoy — `costoPorPorcion` ya incluye el
+ * costo total para esa cobertura.
+ */
+const coberturaSchema = new mongoose.Schema(
+  {
+    slug: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+      match: [/^[a-z0-9-]+$/, "Slug solo permite minúsculas, números y guiones"],
+    },
+    nombre:      { type: String, required: true, trim: true },
+    descripcion: { type: String, trim: true, default: "" },
+
+    // Costo manual por porción del pastel.
+    costoPorPorcion: { type: Number, default: 0, min: 0 },
+
+    // Marca esta cobertura como "fondant" para que el front pueda
+    // mostrar el toggle/pictograma especial de la maqueta.
+    esFondant: { type: Boolean, default: false },
+
+    activo: { type: Boolean, default: true },
+    orden:  { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("CoberturaCotiza", coberturaSchema);

--- a/src/models/cotizacionCatalogos/decoracion.js
+++ b/src/models/cotizacionCatalogos/decoracion.js
@@ -1,0 +1,49 @@
+const mongoose = require("mongoose");
+
+/**
+ * Decoración para la cotización personalizada de pastel.
+ *
+ * Catálogo multi-select (el cliente puede elegir varias). Cada decoración
+ * puede vincularse opcionalmente a una `TecnicaCreativa` ya existente,
+ * de la cual el back resuelve el costo:
+ *
+ *   costo = tecnica.costoBase + tecnica.escalaPorPorcion × porciones
+ *           + tecnica.tiempoHoras × tarifaHora
+ *
+ * Si no hay técnica, se usa `costoManual` plano.
+ *
+ * En la maqueta esto pinta como un `.deco` con emoji + nombre + precio
+ * pequeño. Multi-select.
+ */
+const decoracionSchema = new mongoose.Schema(
+  {
+    slug: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+      match: [/^[a-z0-9-]+$/, "Slug solo permite minúsculas, números y guiones"],
+    },
+    nombre:      { type: String, required: true, trim: true },
+    descripcion: { type: String, trim: true, default: "" },
+    emoji:       { type: String, default: "🎀" },
+
+    // ── Costeo ──────────────────────────────────────────────
+    // Preferido: vincular a una Técnica Creativa existente.
+    tecnicaCreativaId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "TecnicaCreativa",
+      default: null,
+    },
+
+    // Fallback: si no hay técnica, costo plano (no escala con porciones).
+    costoManual: { type: Number, default: 0, min: 0 },
+
+    activo: { type: Boolean, default: true },
+    orden:  { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("DecoracionCotiza", decoracionSchema);

--- a/src/models/cotizacionCatalogos/relleno.js
+++ b/src/models/cotizacionCatalogos/relleno.js
@@ -1,0 +1,35 @@
+const mongoose = require("mongoose");
+
+/**
+ * Sabor del relleno para la cotización personalizada de pastel.
+ *
+ * Catálogo simple: el admin teclea el nombre y el costo extra por
+ * porción manualmente. NO se vincula a recetas porque los rellenos
+ * comunes (ganache, mermelada, dulce de leche) son mezclas pequeñas
+ * que no justifican una receta formal — el costo es estimado.
+ *
+ * En la maqueta esto pinta como un `.opt` simple con texto.
+ */
+const rellenoSchema = new mongoose.Schema(
+  {
+    slug: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+      match: [/^[a-z0-9-]+$/, "Slug solo permite minúsculas, números y guiones"],
+    },
+    nombre:      { type: String, required: true, trim: true },
+    descripcion: { type: String, trim: true, default: "" },
+
+    // Costo manual por porción — el admin lo ajusta a mano.
+    costoPorPorcion: { type: Number, default: 0, min: 0 },
+
+    activo: { type: Boolean, default: true },
+    orden:  { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("RellenoCotiza", rellenoSchema);

--- a/src/models/cotizacionCatalogos/sabor.js
+++ b/src/models/cotizacionCatalogos/sabor.js
@@ -1,0 +1,56 @@
+const mongoose = require("mongoose");
+
+/**
+ * Sabor del bizcocho para la cotización personalizada de pastel.
+ *
+ * El cliente NO compra directo: elige un sabor en /cotizacion y el admin
+ * arma el pastel. Por eso este catálogo guarda metadatos visuales
+ * (swatch / emoji) y un vínculo opcional a una Receta para auto-costeo.
+ *
+ * - Si `recetaId` está presente, el admin puede recostear y obtener
+ *   un snapshot del costo unitario (receta.total_cost / receta.portions).
+ * - Si no, `costoManualPorPorcion` se usa como fallback.
+ *
+ * En la maqueta esto pinta como un `.opt` con un `.csw` (color swatch)
+ * a la izquierda y el nombre + descripción.
+ */
+const saborSchema = new mongoose.Schema(
+  {
+    slug: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true,
+      match: [/^[a-z0-9-]+$/, "Slug solo permite minúsculas, números y guiones"],
+    },
+    nombre:      { type: String, required: true, trim: true },
+    descripcion: { type: String, trim: true, default: "" },
+
+    // Visual — para pintar en el front sin assets externos
+    swatch: { type: String, default: "linear-gradient(135deg,#FFE2E7,#FFC3C9)" },
+    emoji:  { type: String, default: "" },
+
+    // ── Costeo ──────────────────────────────────────────────
+    // Preferido: vincular a una Receta. El admin recostea cuando quiera
+    // y se guarda el snapshot. NO se cobra al cliente — solo se usa en
+    // la vista interna de la cotización para sugerir precio.
+    recetaId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "Receta",
+      default: null,
+    },
+    costoUnitarioSnapshot: { type: Number, default: null, min: 0 },
+    fechaCosteoSnapshot:   { type: Date, default: null },
+
+    // Fallback: si no hay receta, costo manual por porción que el admin
+    // dice "este pan me cuesta ~X por porción".
+    costoManualPorPorcion: { type: Number, default: 0, min: 0 },
+
+    activo: { type: Boolean, default: true },
+    orden:  { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("SaborCotiza", saborSchema);

--- a/src/models/cotizacionPersonalizada.js
+++ b/src/models/cotizacionPersonalizada.js
@@ -1,0 +1,128 @@
+const mongoose = require("mongoose");
+const notaInternaSchema = require("./notaInternaSchema");
+
+/**
+ * CotizacionPersonalizada — modelo unificado del rediseño 2026 de
+ * `/cotizacion`.
+ *
+ * Reemplaza a futuro al viejo `pastelCotiza` pero NO lo borra (los
+ * registros históricos siguen funcionando). Las nuevas cotizaciones que
+ * vienen de la maqueta game-like se guardan aquí.
+ *
+ * Estructura: las 9 secciones de la maqueta + cliente + admin metadata.
+ *
+ * Cada selección de catálogo se guarda como SNAPSHOT (id + slug + nombre
+ * + costoPorPorcionSnapshot cuando aplica). Si el admin después renombra
+ * o ajusta el catálogo, ESTA cotización no cambia.
+ *
+ * El costeo real (link a receta + técnicas) se hace en `costeoSnapshot`
+ * vía el endpoint POST /cotizacion-personalizada/:id/calcular-costeo
+ * (Fase D). Para clientes esto NO se devuelve.
+ */
+
+// ── Sub-snapshots ────────────────────────────────────────────────────
+
+const seleccionCatalogoSnap = new mongoose.Schema(
+  {
+    catalogoId: { type: mongoose.Schema.Types.ObjectId },
+    slug:       { type: String },
+    nombre:     { type: String },
+    // Costo congelado al momento de crear la cotización — opcional
+    // (sabor lo resuelve por receta más tarde, por eso puede venir null).
+    costoSnapshot: { type: Number, default: null },
+    // Para cobertura, congelamos si era fondant.
+    esFondant: { type: Boolean, default: false },
+  },
+  { _id: false }
+);
+
+// ── Schema principal ─────────────────────────────────────────────────
+
+const cotizacionPersonalizadaSchema = new mongoose.Schema(
+  {
+    // ── 1. Evento ────────────────────────────────────────────────
+    evento: {
+      tipo:      { type: String, required: true },  // "boda" | "xv" | "cumple" | ...
+      fecha:     { type: Date,   required: true },
+      invitados: { type: Number, required: true, min: 1 },
+    },
+
+    // ── 2. Niveles del pastel ────────────────────────────────────
+    niveles: { type: Number, required: true, min: 1, max: 6, default: 1 },
+
+    // ── 3. Sabor del bizcocho ────────────────────────────────────
+    sabor: { type: seleccionCatalogoSnap, default: null },
+
+    // ── 4. Sabor del relleno ─────────────────────────────────────
+    relleno: { type: seleccionCatalogoSnap, default: null },
+
+    // ── 5. Cobertura ─────────────────────────────────────────────
+    cobertura:      { type: seleccionCatalogoSnap, default: null },
+    colorPrincipal: { type: String, default: "" }, // hex "#FFC9D4" o nombre
+
+    // ── 6. Decoraciones (multi-select) ───────────────────────────
+    decoraciones: { type: [seleccionCatalogoSnap], default: [] },
+
+    // ── 7. Estilo + inspiración ──────────────────────────────────
+    estilo: {
+      value:       { type: String, default: "" }, // "minimalista" | "elegante" | ...
+      comentarios: { type: String, default: "" },
+      imagenesInspiracion: { type: [String], default: [] }, // URLs subidas
+    },
+
+    // ── 8. Entrega ───────────────────────────────────────────────
+    entrega: {
+      tipo:      { type: String, default: "" }, // "recoger" | "domicilio" | ...
+      fecha:     { type: Date,   default: null }, // a veces igual al evento, a veces 1 día antes
+      hora:      { type: String, default: "" }, // HH:mm
+      direccion: { type: String, default: "" },
+    },
+
+    // ── 9. Cliente ───────────────────────────────────────────────
+    cliente: {
+      nombre:   { type: String, required: true, trim: true },
+      telefono: {
+        type: String,
+        required: true,
+        // Permitir tanto el formato XXX-XXX-XXXX como variantes con +52,
+        // espacios, etc. Validamos largo mínimo y que tenga ≥10 dígitos.
+        validate: {
+          validator: (v) => (v || "").replace(/\D/g, "").length >= 10,
+          message: "Teléfono debe tener al menos 10 dígitos",
+        },
+      },
+      email:   { type: String, default: "", trim: true, lowercase: true },
+    },
+
+    // ── Admin metadata ───────────────────────────────────────────
+    status: { type: String, default: "Pendiente" },
+    userId: { type: String, default: "" }, // si vino de un cliente loggeado
+
+    // Precio cerrado por el admin (después de costeo + decisión humana)
+    precio:         { type: Number },
+    anticipo:       { type: Number },
+    saldoPendiente: { type: Number, default: 0 },
+
+    // Snapshot del cálculo automático — se llena con
+    // POST /cotizacion-personalizada/:id/calcular-costeo (Fase D)
+    costeoSnapshot: { type: mongoose.Schema.Types.Mixed, default: null },
+
+    // Evento de Google Calendar (si la cotización se agenda)
+    calendarEventId: { type: String, default: "" },
+    reminderSentAt:  { type: Date },
+
+    // Notas internas append-only (mismo patrón que pastelCotiza)
+    notasInternas: { type: [notaInternaSchema], default: [] },
+  },
+  { timestamps: true }
+);
+
+// Índices útiles para listar en admin: por status + fecha del evento.
+cotizacionPersonalizadaSchema.index({ status: 1, "evento.fecha": 1 });
+cotizacionPersonalizadaSchema.index({ "cliente.email": 1 });
+cotizacionPersonalizadaSchema.index({ userId: 1 });
+
+module.exports = mongoose.model(
+  "CotizacionPersonalizada",
+  cotizacionPersonalizadaSchema
+);

--- a/src/routes/cotizacionCatalogos/_crudFactory.js
+++ b/src/routes/cotizacionCatalogos/_crudFactory.js
@@ -1,0 +1,113 @@
+const express = require("express");
+const checkRoleToken = require("../../middlewares/myRoleToken");
+
+/**
+ * Factory de un router CRUD estándar para los 4 catálogos de cotización
+ * (sabor, relleno, cobertura, decoración).
+ *
+ * Comportamiento común:
+ * - GET /        → listado público. Solo `activo:true` por default.
+ *                  ?incluyeInactivos=true para que el admin vea todos.
+ * - GET /:id     → detalle (público también — el front lo usa en la
+ *                  vista de detalle de cotización para resolver slugs).
+ * - POST /       → admin. Recibe whitelist de campos.
+ * - PUT /:id     → admin. Misma whitelist.
+ * - DELETE /:id  → admin. Hard delete (los catálogos no se referencian
+ *                  por ObjectId en cotizaciones — se snapshotean, ver
+ *                  modelo CotizacionPersonalizada).
+ *
+ * El llamador especifica:
+ *  - Model: modelo mongoose
+ *  - camposEditables: array de strings whitelist
+ *  - populate (opcional): array de paths a popular en GET
+ */
+function crudFactory({ Model, camposEditables, populate = [] }) {
+  const router = express.Router();
+
+  const pickEditables = (body) => {
+    const out = {};
+    for (const k of camposEditables) {
+      if (Object.prototype.hasOwnProperty.call(body || {}, k)) out[k] = body[k];
+    }
+    return out;
+  };
+
+  const applyPopulate = (q) => {
+    for (const p of populate) q = q.populate(p);
+    return q;
+  };
+
+  router.get("/", async (req, res) => {
+    try {
+      const filter = {};
+      if (req.query.incluyeInactivos !== "true") filter.activo = true;
+      const docs = await applyPopulate(Model.find(filter)).sort({ orden: 1, createdAt: -1 });
+      res.json({ data: docs });
+    } catch (e) {
+      console.error(`Error listando ${Model.modelName}:`, e);
+      res.status(500).json({ message: e.message });
+    }
+  });
+
+  router.get("/:idOrSlug", async (req, res) => {
+    try {
+      const { idOrSlug } = req.params;
+      const isObjectId = /^[0-9a-fA-F]{24}$/.test(idOrSlug);
+      const doc = isObjectId
+        ? await applyPopulate(Model.findById(idOrSlug))
+        : await applyPopulate(Model.findOne({ slug: idOrSlug }));
+      if (!doc) return res.status(404).json({ message: `${Model.modelName} no encontrado` });
+      res.json({ data: doc });
+    } catch (e) {
+      console.error(`Error obteniendo ${Model.modelName}:`, e);
+      res.status(500).json({ message: e.message });
+    }
+  });
+
+  router.post("/", checkRoleToken("admin"), async (req, res) => {
+    try {
+      const data = pickEditables(req.body);
+      const doc = await Model.create(data);
+      res.status(201).json({ message: `${Model.modelName} creado`, data: doc });
+    } catch (e) {
+      if (e.code === 11000) {
+        return res.status(409).json({ message: `Ya existe ${Model.modelName} con ese slug` });
+      }
+      console.error(`Error creando ${Model.modelName}:`, e);
+      res.status(400).json({ message: e.message });
+    }
+  });
+
+  router.put("/:id", checkRoleToken("admin"), async (req, res) => {
+    try {
+      const data = pickEditables(req.body);
+      const doc = await Model.findByIdAndUpdate(req.params.id, data, {
+        new: true,
+        runValidators: true,
+      });
+      if (!doc) return res.status(404).json({ message: `${Model.modelName} no encontrado` });
+      res.json({ message: `${Model.modelName} actualizado`, data: doc });
+    } catch (e) {
+      if (e.code === 11000) {
+        return res.status(409).json({ message: `Ya existe ${Model.modelName} con ese slug` });
+      }
+      console.error(`Error actualizando ${Model.modelName}:`, e);
+      res.status(400).json({ message: e.message });
+    }
+  });
+
+  router.delete("/:id", checkRoleToken("admin"), async (req, res) => {
+    try {
+      const doc = await Model.findByIdAndDelete(req.params.id);
+      if (!doc) return res.status(404).json({ message: `${Model.modelName} no encontrado` });
+      res.json({ message: `${Model.modelName} eliminado` });
+    } catch (e) {
+      console.error(`Error eliminando ${Model.modelName}:`, e);
+      res.status(400).json({ message: e.message });
+    }
+  });
+
+  return router;
+}
+
+module.exports = crudFactory;

--- a/src/routes/cotizacionCatalogos/coberturas.js
+++ b/src/routes/cotizacionCatalogos/coberturas.js
@@ -1,0 +1,15 @@
+const CoberturaCotiza = require("../../models/cotizacionCatalogos/cobertura");
+const crudFactory = require("./_crudFactory");
+
+module.exports = crudFactory({
+  Model: CoberturaCotiza,
+  camposEditables: [
+    "slug",
+    "nombre",
+    "descripcion",
+    "costoPorPorcion",
+    "esFondant",
+    "activo",
+    "orden",
+  ],
+});

--- a/src/routes/cotizacionCatalogos/decoraciones.js
+++ b/src/routes/cotizacionCatalogos/decoraciones.js
@@ -1,0 +1,17 @@
+const DecoracionCotiza = require("../../models/cotizacionCatalogos/decoracion");
+const crudFactory = require("./_crudFactory");
+
+module.exports = crudFactory({
+  Model: DecoracionCotiza,
+  camposEditables: [
+    "slug",
+    "nombre",
+    "descripcion",
+    "emoji",
+    "tecnicaCreativaId",
+    "costoManual",
+    "activo",
+    "orden",
+  ],
+  populate: ["tecnicaCreativaId"],
+});

--- a/src/routes/cotizacionCatalogos/index.js
+++ b/src/routes/cotizacionCatalogos/index.js
@@ -1,0 +1,21 @@
+const express = require("express");
+const router = express.Router();
+
+/**
+ * Mount-point único para los 4 catálogos de cotización personalizada.
+ *
+ * Se monta en index.js como:
+ *   app.use("/cotizacion-catalogos", cotizacionCatalogosRoutes);
+ *
+ * Resulta en:
+ *   /cotizacion-catalogos/sabores
+ *   /cotizacion-catalogos/rellenos
+ *   /cotizacion-catalogos/coberturas
+ *   /cotizacion-catalogos/decoraciones
+ */
+router.use("/sabores",      require("./sabores"));
+router.use("/rellenos",     require("./rellenos"));
+router.use("/coberturas",   require("./coberturas"));
+router.use("/decoraciones", require("./decoraciones"));
+
+module.exports = router;

--- a/src/routes/cotizacionCatalogos/rellenos.js
+++ b/src/routes/cotizacionCatalogos/rellenos.js
@@ -1,0 +1,14 @@
+const RellenoCotiza = require("../../models/cotizacionCatalogos/relleno");
+const crudFactory = require("./_crudFactory");
+
+module.exports = crudFactory({
+  Model: RellenoCotiza,
+  camposEditables: [
+    "slug",
+    "nombre",
+    "descripcion",
+    "costoPorPorcion",
+    "activo",
+    "orden",
+  ],
+});

--- a/src/routes/cotizacionCatalogos/sabores.js
+++ b/src/routes/cotizacionCatalogos/sabores.js
@@ -1,0 +1,61 @@
+const express = require("express");
+const SaborCotiza = require("../../models/cotizacionCatalogos/sabor");
+const Receta = require("../../models/recetas/recetas");
+const checkRoleToken = require("../../middlewares/myRoleToken");
+const crudFactory = require("./_crudFactory");
+
+/**
+ * Sabores del bizcocho — CRUD + recosteo desde receta.
+ *
+ * El recosteo es admin-only y opera análogo a galletaSabores: lee la
+ * receta vinculada, calcula `total_cost / portions` y lo guarda en
+ * `costoUnitarioSnapshot`. El cliente NUNCA ve ese costo — solo el
+ * desglose interno de la cotización lo usa.
+ */
+const router = crudFactory({
+  Model: SaborCotiza,
+  camposEditables: [
+    "slug",
+    "nombre",
+    "descripcion",
+    "swatch",
+    "emoji",
+    "recetaId",
+    "costoManualPorPorcion",
+    "activo",
+    "orden",
+  ],
+  populate: ["recetaId"],
+});
+
+/**
+ * POST /sabores/:id/recostear — admin.
+ *
+ * Resuelve la receta vinculada y guarda el snapshot de costo unitario.
+ * Devuelve el sabor actualizado con el nuevo snapshot.
+ */
+router.post("/:id/recostear", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const sabor = await SaborCotiza.findById(req.params.id);
+    if (!sabor) return res.status(404).json({ message: "Sabor no encontrado" });
+    if (!sabor.recetaId) {
+      return res.status(400).json({ message: "Este sabor no tiene receta vinculada" });
+    }
+    const receta = await Receta.findById(sabor.recetaId);
+    if (!receta) return res.status(404).json({ message: "Receta vinculada no existe" });
+    if (!receta.portions || receta.portions <= 0) {
+      return res.status(400).json({ message: "La receta no tiene `portions` válido" });
+    }
+
+    sabor.costoUnitarioSnapshot = Math.round((receta.total_cost / receta.portions) * 100) / 100;
+    sabor.fechaCosteoSnapshot = new Date();
+    await sabor.save();
+
+    res.json({ message: "Sabor recosteado", data: sabor });
+  } catch (e) {
+    console.error("Error recosteando sabor:", e);
+    res.status(400).json({ message: e.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/cotizacionPersonalizada.js
+++ b/src/routes/cotizacionPersonalizada.js
@@ -1,0 +1,190 @@
+const express = require("express");
+const router = express.Router();
+const CotizacionPersonalizada = require("../models/cotizacionPersonalizada");
+const SaborCotiza = require("../models/cotizacionCatalogos/sabor");
+const RellenoCotiza = require("../models/cotizacionCatalogos/relleno");
+const CoberturaCotiza = require("../models/cotizacionCatalogos/cobertura");
+const DecoracionCotiza = require("../models/cotizacionCatalogos/decoracion");
+const checkRoleToken = require("../middlewares/myRoleToken");
+const { requireAuth } = checkRoleToken;
+const { syncCotizacionCalendar } = require("../utils/cotizacionCalendarSync");
+const { mountNotaInternaRoutes } = require("../utils/notaInternaRoute");
+
+/**
+ * Rutas para la cotización personalizada de pastel (rediseño 2026).
+ *
+ * Patrón:
+ *  - POST público con payload nested (evento, sabor, relleno, etc.).
+ *    El back resuelve los slugs de catálogo a snapshots y los congela.
+ *  - GET admin = todo, GET user = solo suyas, GET por id = público pero
+ *    sin notasInternas ni costeoSnapshot.
+ *  - PUT solo admin.
+ *  - Notas internas reusando mountNotaInternaRoutes.
+ *  - Sync de Calendar al actualizar status.
+ */
+
+mountNotaInternaRoutes(router, CotizacionPersonalizada, "Cotización Personalizada");
+
+// ── Helpers de resolución de slugs → snapshots ────────────────────
+
+async function snapshotSabor(slug) {
+  if (!slug) return null;
+  const s = await SaborCotiza.findOne({ slug, activo: true });
+  if (!s) return null;
+  return {
+    catalogoId: s._id,
+    slug: s.slug,
+    nombre: s.nombre,
+    costoSnapshot: s.costoUnitarioSnapshot ?? s.costoManualPorPorcion ?? null,
+  };
+}
+
+async function snapshotRelleno(slug) {
+  if (!slug) return null;
+  const r = await RellenoCotiza.findOne({ slug, activo: true });
+  if (!r) return null;
+  return {
+    catalogoId: r._id,
+    slug: r.slug,
+    nombre: r.nombre,
+    costoSnapshot: r.costoPorPorcion ?? 0,
+  };
+}
+
+async function snapshotCobertura(slug) {
+  if (!slug) return null;
+  const c = await CoberturaCotiza.findOne({ slug, activo: true });
+  if (!c) return null;
+  return {
+    catalogoId: c._id,
+    slug: c.slug,
+    nombre: c.nombre,
+    costoSnapshot: c.costoPorPorcion ?? 0,
+    esFondant: !!c.esFondant,
+  };
+}
+
+async function snapshotDecoraciones(slugs) {
+  if (!Array.isArray(slugs) || slugs.length === 0) return [];
+  const docs = await DecoracionCotiza.find({ slug: { $in: slugs }, activo: true });
+  return docs.map((d) => ({
+    catalogoId: d._id,
+    slug: d.slug,
+    nombre: d.nombre,
+    // En este snapshot guardamos costoManual cuando no hay técnica.
+    // Si hay técnica, el costo real se calcula en /calcular-costeo
+    // (Fase D) leyendo la técnica viva — aquí no escalamos por porción.
+    costoSnapshot: d.tecnicaCreativaId ? null : (d.costoManual ?? 0),
+  }));
+}
+
+// ── POST público — crear nueva cotización ─────────────────────────
+
+router.post("/", async (req, res) => {
+  try {
+    const body = req.body || {};
+
+    // Resolver snapshots de catálogo en paralelo.
+    const [sabor, relleno, cobertura, decoraciones] = await Promise.all([
+      snapshotSabor(body.saborSlug),
+      snapshotRelleno(body.rellenoSlug),
+      snapshotCobertura(body.coberturaSlug),
+      snapshotDecoraciones(body.decoracionesSlugs || []),
+    ]);
+
+    const doc = await CotizacionPersonalizada.create({
+      evento: body.evento,
+      niveles: body.niveles,
+      sabor,
+      relleno,
+      cobertura,
+      colorPrincipal: body.colorPrincipal || "",
+      decoraciones,
+      estilo: body.estilo || {},
+      entrega: body.entrega || {},
+      cliente: body.cliente,
+      userId: body.userId || "",
+    });
+
+    res.status(201).json({ message: "Cotización creada", data: doc });
+  } catch (e) {
+    console.error("Error creando cotización personalizada:", e);
+    res.status(400).json({ message: e.message });
+  }
+});
+
+// ── GET admin = todo, user = suyas ───────────────────────────────
+
+router.get("/", requireAuth, async (req, res) => {
+  try {
+    const filter = req.user.role === "admin" ? {} : { userId: String(req.user._id) };
+    const projection = req.user.role === "admin" ? "" : "-notasInternas -costeoSnapshot";
+    const data = await CotizacionPersonalizada.find(filter)
+      .select(projection)
+      .sort({ createdAt: -1 });
+    res.json({ data, total: data.length });
+  } catch (e) {
+    console.error("Error listando cotizaciones personalizadas:", e);
+    res.status(500).json({ message: e.message });
+  }
+});
+
+// ── GET por id — público (admin ve TODO via header role) ─────────
+
+router.get("/:id", async (req, res) => {
+  try {
+    // Si viene con auth y role admin → todo; si no, sin notas ni costeo.
+    let isAdmin = false;
+    const token = req.headers.authorization?.split(" ")[1];
+    if (token) {
+      try {
+        const jwt = require("jsonwebtoken");
+        const decoded = jwt.verify(token, process.env.JWT_SIGN);
+        isAdmin = decoded?.role === "admin";
+      } catch (_) { /* token inválido → seguir como público */ }
+    }
+    const projection = isAdmin ? "" : "-notasInternas -costeoSnapshot";
+    const doc = await CotizacionPersonalizada.findById(req.params.id).select(projection);
+    if (!doc) return res.status(404).json({ message: "Cotización no encontrada" });
+    res.json({ data: doc });
+  } catch (e) {
+    console.error("Error obteniendo cotización personalizada:", e);
+    res.status(500).json({ message: e.message });
+  }
+});
+
+// ── PUT — admin ──────────────────────────────────────────────────
+
+router.put("/:id", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const doc = await CotizacionPersonalizada.findByIdAndUpdate(
+      req.params.id,
+      req.body,
+      { new: true, runValidators: true }
+    );
+    if (!doc) return res.status(404).json({ message: "Cotización no encontrada" });
+
+    // Sync Calendar igual que en pastelCotiza.
+    syncCotizacionCalendar(CotizacionPersonalizada, doc, "Pastel");
+
+    res.json({ message: "Cotización actualizada", data: doc });
+  } catch (e) {
+    console.error("Error actualizando cotización personalizada:", e);
+    res.status(400).json({ message: e.message });
+  }
+});
+
+// ── DELETE — admin ───────────────────────────────────────────────
+
+router.delete("/:id", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const doc = await CotizacionPersonalizada.findByIdAndDelete(req.params.id);
+    if (!doc) return res.status(404).json({ message: "Cotización no encontrada" });
+    res.json({ message: "Cotización eliminada" });
+  } catch (e) {
+    console.error("Error eliminando cotización personalizada:", e);
+    res.status(400).json({ message: e.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary

Primera fase del rediseño de `/cotizacion` (game-like, basado en la maqueta de Design System). Solo back.

### Catálogos nuevos
- `SaborCotiza` — con `recetaId` opcional + snapshot de costo unitario (POST `/sabores/:id/recostear`).
- `RellenoCotiza` — costo manual por porción.
- `CoberturaCotiza` — costo manual + `esFondant` flag para el toggle de la maqueta.
- `DecoracionCotiza` — `tecnicaCreativaId` opcional (Fase D usa esto para auto-costeo) + `costoManual` fallback.
- CRUD admin compartido via `_crudFactory.js`. GET público para que `/cotizacion` lea.

### Modelo unificado
`CotizacionPersonalizada` reflejando las 9 secciones de la maqueta:
1. evento (tipo, fecha, invitados)
2. niveles
3. sabor (snapshot del catálogo)
4. relleno
5. cobertura + colorPrincipal
6. decoraciones[] (multi-select)
7. estilo (value, comentarios, imágenes de inspiración)
8. entrega (tipo, fecha, hora, dirección)
9. cliente

Snapshots de catálogo congelados al crear → si el admin renombra después, esta cotización no cambia (mismo principio que reseñas/sub-recetas).

### Endpoints
| Método | URL | Auth |
|---|---|---|
| `GET` | `/cotizacion-catalogos/{sabores,rellenos,coberturas,decoraciones}` | público |
| `POST/PUT/DELETE` | mismo prefix | admin |
| `POST` | `/cotizacion-catalogos/sabores/:id/recostear` | admin |
| `POST` | `/cotizacion-personalizada` | público |
| `GET` | `/cotizacion-personalizada` | auth (admin todo, user → suyas) |
| `GET` | `/cotizacion-personalizada/:id` | público (sin notas/costeo si no admin) |
| `PUT/DELETE` | `/cotizacion-personalizada/:id` | admin |
| `POST/DELETE` | `/cotizacion-personalizada/:id/notas-internas*` | admin |

Sync de Google Calendar con `syncCotizacionCalendar` (reusado de pastelCotiza).

## Test plan
- [ ] Crear sabor con receta y recostearlo → `costoUnitarioSnapshot` se llena.
- [ ] Crear cotización personalizada con `saborSlug`, `rellenoSlug`, etc. → snapshots correctos.
- [ ] GET público de cotización NO devuelve `notasInternas` ni `costeoSnapshot`.
- [ ] GET con header admin SÍ devuelve todo.
- [ ] Status → "Agendado..." crea evento de Calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)