### PR TITLE
feat(cotizacion): Fase D back — endpoint /calcular-costeo

### DIFF
--- a/src/routes/cotizacionPersonalizada.js
+++ b/src/routes/cotizacionPersonalizada.js
@@ -5,10 +5,18 @@ const SaborCotiza = require("../models/cotizacionCatalogos/sabor");
 const RellenoCotiza = require("../models/cotizacionCatalogos/relleno");
 const CoberturaCotiza = require("../models/cotizacionCatalogos/cobertura");
 const DecoracionCotiza = require("../models/cotizacionCatalogos/decoracion");
+const Receta = require("../models/recetas/recetas");
+const Cost = require("../models/costs");
 const checkRoleToken = require("../middlewares/myRoleToken");
 const { requireAuth } = checkRoleToken;
 const { syncCotizacionCalendar } = require("../utils/cotizacionCalendarSync");
 const { mountNotaInternaRoutes } = require("../utils/notaInternaRoute");
+
+// Multiplicador de complejidad por número de pisos. Mismo valor que usa
+// el front en cakePersonalizado.jsx para que el estimado del cliente
+// coincida con el cálculo admin del back.
+const MULTIPLICADOR_NIVELES = { 1: 1, 2: 1.25, 3: 1.55, 4: 1.95, 5: 2.35, 6: 2.75 };
+function round2(n) { return Math.round(n * 100) / 100; }
 
 /**
  * Rutas para la cotización personalizada de pastel (rediseño 2026).
@@ -170,6 +178,158 @@ router.put("/:id", checkRoleToken("admin"), async (req, res) => {
     res.json({ message: "Cotización actualizada", data: doc });
   } catch (e) {
     console.error("Error actualizando cotización personalizada:", e);
+    res.status(400).json({ message: e.message });
+  }
+});
+
+// ── POST /:id/calcular-costeo — admin ────────────────────────────
+//
+// Resuelve receta del sabor + técnica creativa de cada decoración y
+// produce un breakdown del costo REAL (no el estimado cliente-side).
+//
+// Algoritmo:
+//   inv  = cotizacion.evento.invitados
+//   mult = MULTIPLICADOR_NIVELES[niveles] (más pisos = más trabajo)
+//
+//   costoBizcocho   = unitarioReceta × inv × mult
+//   costoRelleno    = relleno.costoPorPorcion × inv × mult
+//   costoCobertura  = cobertura.costoPorPorcion × inv × mult
+//   costoDecoraciones = Σ (técnica.costoBase + escalaPorPorcion × inv
+//                                            + tiempoHoras × tarifaHora)
+//                       || decoracion.costoManual
+//
+//   costoTotal     = bizcocho + relleno + cobertura + decoraciones
+//   precioSugerido = costoTotal × (1 + markup)
+//
+// Guarda el snapshot en cotizacion.costeoSnapshot. Re-ejecutable
+// (sobrescribe).
+
+router.post("/:id/calcular-costeo", checkRoleToken("admin"), async (req, res) => {
+  try {
+    const cot = await CotizacionPersonalizada.findById(req.params.id);
+    if (!cot) return res.status(404).json({ message: "Cotización no encontrada" });
+
+    const inv     = Math.max(1, Number(cot.evento?.invitados) || 0);
+    const niveles = cot.niveles || 1;
+    const mult    = MULTIPLICADOR_NIVELES[niveles] ?? 1;
+
+    // Markup: del body si viene, sino de Cost global (default 60%).
+    const cfg = await Cost.findOne();
+    const markup = typeof req.body.markupPct === "number"
+      ? req.body.markupPct
+      : (cfg?.markupCotizacionesPct ?? cfg?.markupPostresPct ?? 60);
+    const tarifaHora = cfg?.laborCosts ?? 0;
+
+    // ── Bizcocho ─────────────────────────────────────────────────
+    let costoBizcocho = 0;
+    let bizcochoDetalle = null;
+    if (cot.sabor?.catalogoId) {
+      const sabor = await SaborCotiza.findById(cot.sabor.catalogoId).populate("recetaId");
+      if (sabor) {
+        let unitario = 0;
+        let fuente = "manual";
+        if (sabor.recetaId && sabor.recetaId.portions > 0) {
+          unitario = sabor.recetaId.total_cost / sabor.recetaId.portions;
+          fuente = "receta";
+        } else {
+          unitario = sabor.costoUnitarioSnapshot ?? sabor.costoManualPorPorcion ?? 0;
+        }
+        costoBizcocho = round2(unitario * inv * mult);
+        bizcochoDetalle = {
+          slug: sabor.slug,
+          nombre: sabor.nombre,
+          costoUnitario: round2(unitario),
+          fuente,
+          recetaId: sabor.recetaId?._id || null,
+          recetaNombre: sabor.recetaId?.nombre_receta || null,
+        };
+      }
+    }
+
+    // ── Relleno ──────────────────────────────────────────────────
+    let costoRelleno = 0;
+    let rellenoDetalle = null;
+    if (cot.relleno?.catalogoId) {
+      const rel = await RellenoCotiza.findById(cot.relleno.catalogoId);
+      if (rel) {
+        costoRelleno = round2((rel.costoPorPorcion || 0) * inv * mult);
+        rellenoDetalle = { slug: rel.slug, nombre: rel.nombre, costoUnitario: rel.costoPorPorcion };
+      }
+    }
+
+    // ── Cobertura ────────────────────────────────────────────────
+    let costoCobertura = 0;
+    let coberturaDetalle = null;
+    if (cot.cobertura?.catalogoId) {
+      const cob = await CoberturaCotiza.findById(cot.cobertura.catalogoId);
+      if (cob) {
+        costoCobertura = round2((cob.costoPorPorcion || 0) * inv * mult);
+        coberturaDetalle = {
+          slug: cob.slug, nombre: cob.nombre,
+          costoUnitario: cob.costoPorPorcion, esFondant: cob.esFondant,
+        };
+      }
+    }
+
+    // ── Decoraciones ─────────────────────────────────────────────
+    const decoIds = (cot.decoraciones || []).map((d) => d.catalogoId).filter(Boolean);
+    const decoDocs = await DecoracionCotiza.find({ _id: { $in: decoIds } }).populate("tecnicaCreativaId");
+    const decoracionesDetalle = [];
+    let costoDecoraciones = 0;
+    for (const d of decoDocs) {
+      let costo = 0;
+      let fuente = "manual";
+      if (d.tecnicaCreativaId) {
+        const t = d.tecnicaCreativaId;
+        costo = (t.costoBase || 0) + (t.escalaPorPorcion || 0) * inv + (t.tiempoHoras || 0) * tarifaHora;
+        fuente = "tecnica";
+      } else {
+        costo = d.costoManual || 0;
+      }
+      costo = round2(costo);
+      costoDecoraciones += costo;
+      decoracionesDetalle.push({
+        slug: d.slug,
+        nombre: d.nombre,
+        costo,
+        fuente,
+        tecnicaId: d.tecnicaCreativaId?._id || null,
+        tecnicaNombre: d.tecnicaCreativaId?.nombre || null,
+      });
+    }
+    costoDecoraciones = round2(costoDecoraciones);
+
+    // ── Totales ──────────────────────────────────────────────────
+    const costoTotal     = round2(costoBizcocho + costoRelleno + costoCobertura + costoDecoraciones);
+    const precioSugerido = round2(costoTotal * (1 + markup / 100));
+    const gananciaNeta   = round2(precioSugerido - costoTotal);
+
+    const snapshot = {
+      fechaCosteo: new Date(),
+      invitados: inv,
+      niveles,
+      multiplicadorNiveles: mult,
+      tarifaHora,
+      bizcocho: bizcochoDetalle,
+      costoBizcocho,
+      relleno: rellenoDetalle,
+      costoRelleno,
+      cobertura: coberturaDetalle,
+      costoCobertura,
+      decoraciones: decoracionesDetalle,
+      costoDecoraciones,
+      costoTotal,
+      markupPct: markup,
+      precioSugerido,
+      gananciaNeta,
+    };
+
+    cot.costeoSnapshot = snapshot;
+    await cot.save();
+
+    res.json({ message: "Costeo calculado", data: snapshot });
+  } catch (e) {
+    console.error("Error calculando costeo:", e);
     res.status(400).json({ message: e.message });
   }
 });


### PR DESCRIPTION
## Summary

Cuarta fase del rediseño de `/cotizacion`. Solo back.

**Base:** PR #84 (Fase A). Mergear este DESPUÉS o cambiar base a main cuando #84 mergeé.

### Endpoint
`POST /cotizacion-personalizada/:id/calcular-costeo` (admin)

Cálculo:
- **Bizcocho:** sabor.recetaId → receta.total_cost/portions × invitados × multiplicadorNiveles
- **Relleno + Cobertura:** costoPorPorcion × inv × mult
- **Cada decoración:** técnica.costoBase + escalaPorPorcion × inv + tiempoHoras × tarifaHora (o costoManual si no hay técnica)
- **Total:** suma componentes × (1 + markup%)

Markup desde body, sino `Cost.markupCotizacionesPct`, sino `markupPostresPct`, sino 60%.

Guarda el breakdown completo en `cotizacion.costeoSnapshot`. Re-ejecutable (sobrescribe).

### Multiplicador de niveles
| Niveles | Multiplicador |
|---|---|
| 1 | 1.00 |
| 2 | 1.25 |
| 3 | 1.55 |
| 4 | 1.95 |
| 5 | 2.35 |
| 6 | 2.75 |

Misma tabla que el front (cakePersonalizado.jsx) — estimado cliente y cálculo admin quedan alineados.

## Test plan
- [ ] Crear cotización con sabor + receta + 2 decoraciones con técnicas.
- [ ] POST `/cotizacion-personalizada/:id/calcular-costeo` → respuesta con breakdown completo.
- [ ] Re-ejecutar → sobrescribe sin error.
- [ ] Verificar `costoSnapshot.precioSugerido` ~ estimado del cliente × markup real.
- [ ] markupPct override en body funciona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)